### PR TITLE
fix: expiring incorrect key

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,11 @@ H -- Response provided --> C
 - `GET /request/:id`: Called by World App. Used to fetch the proof verification request. One time use.
 - `PUT /response/:id`: Called by World App. Used to send the proof back to the application.
 - `GET /response/:id`: Called by IDKit. Continuous pulling to fetch the status of the request and the response if available. Response can only be retrieved once.
+
+## Local Development
+
+An easy way to run is using a Dockerized Redis:
+
+```
+docker run -d -p 6379:6379 redis
+```

--- a/src/routes/response.rs
+++ b/src/routes/response.rs
@@ -99,9 +99,9 @@ async fn insert_response(
     }
 
     redis
-        .expire::<_, ()>(&request_id.to_string(), EXPIRE_AFTER_SECONDS)
+        .expire::<_, ()>(format!("{RES_PREFIX}{request_id}"), EXPIRE_AFTER_SECONDS)
         .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+        .map_err(handle_redis_error)?;
 
     //ANCHOR - Delete status
     //NOTE - We can delete the status now as the presence of a response implies the request is complete


### PR DESCRIPTION
Fixes:
- We were expiring the response with an incorrect key.
- We now reject requests to PUT a response for an invalid request ID.
- We store the response in Redis with an expiration atomically.
- Deleting the status key had an incorrect return type causing a 500.  