### PR TITLE
[ID-760] change HEAD behavior

### DIFF
--- a/src/routes/request.rs
+++ b/src/routes/request.rs
@@ -57,7 +57,7 @@ async fn has_request(
     Extension(mut redis): Extension<ConnectionManager>,
 ) -> StatusCode {
     let Ok(exists) = redis
-        .exists::<_, bool>(format!("{REQ_STATUS_PREFIX}{request_id}"))
+        .exists::<_, bool>(format!("{REQ_PREFIX}{request_id}"))
         .await
     else {
         return StatusCode::INTERNAL_SERVER_ERROR;


### PR DESCRIPTION
At present a HEAD request to `/request/:request_id` returns 200 when a request ID has (or had) a status record

Instead, we'd like to represent a 200 as "the payload is fetchable."

This changes the behavior, to have HEAD check the payload key instead of the status key so it returns 200 only while the payload is still fetchable, and 404 after it’s been retrieved or never existed.