### PR TITLE
feat: add ca certs to docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,8 @@ RUN apt-get update && apt-get install -y \
     musl-tools \
     pkg-config \
     build-essential \
- && rm -rf /var/lib/apt/lists/*
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN rustup target add x86_64-unknown-linux-musl
 


### PR DESCRIPTION
the root CAs are needed to connect to Redis via TLS