### PR TITLE
fix: redis + rustls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1007,6 +1007,7 @@ dependencies = [
  "tokio-rustls",
  "tokio-util",
  "url",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1707,6 +1708,15 @@ name = "wasm-bindgen-shared"
 version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e8983c3ab33d6fb807cfcdad2491c4ea8cbc8ed839181c7dfd9c67c83e261b2"
+dependencies = [
+ "rustls-pki-types",
+]
 
 [[package]]
 name = "windows-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ redis = { version = "0.32.5", features = [
     "tokio-comp",
     "connection-manager",
     "tokio-rustls-comp",
+    "tls-rustls-webpki-roots",
 ] }
 rustls = { version = "0.23.31", default-features = false, features = ["ring"] }
 schemars = { version = "0.8.16", features = ["uuid1"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,6 @@ FROM scratch
 
 WORKDIR /app
 
-COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /app/target/x86_64-unknown-linux-musl/release/world-id-bridge /app/world-id-bridge
 
 USER 100

--- a/deny.toml
+++ b/deny.toml
@@ -18,6 +18,7 @@ allow = [
     "BSD-2-Clause",
     "BSD-3-Clause",
     "BSL-1.0",
+    "CDLA-Permissive-2.0",
     "ISC",
     "LicenseRef-ring",
     "MIT",


### PR DESCRIPTION
Web app can't connect to elasticache Redis through TLS, installing certs from webkpi-roots and adding better error logging.