### PR TITLE
Update cargo-deny-action to v2.0.15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,6 @@ jobs:
           toolchain: stable
 
       - name: Run cargo-deny
-        uses: EmbarkStudios/cargo-deny-action@30f817c6f72275c6d54dc744fbca09ebc958599f # v2.0.12 https://github.com/EmbarkStudios/cargo-deny-action/releases/tag/v2.0.12
+        uses: EmbarkStudios/cargo-deny-action@3fd3802e88374d3fe9159b834c7714ec57d6c979 # v2.0.15 https://github.com/EmbarkStudios/cargo-deny-action/releases/tag/v2.0.15
         with:
           command: check

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,9 +215,9 @@ checksum = "5ce89b21cab1437276d2650d57e971f9d548a2d9037cc231abdc0562b97498ce"
 
 [[package]]
 name = "bytes"
-version = "1.6.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"

--- a/deny.toml
+++ b/deny.toml
@@ -34,6 +34,4 @@ license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
 name = "ring"
 
 [advisories]
-ignore = [
-    "RUSTSEC-2025-0056", # adler2 unmaintained (requires upstream updates) (2025-09-09)
-]
+ignore = []


### PR DESCRIPTION
- updated from v2.0.12 to v2.0.15 to support CVSS 4.0 advisories
- fixes deny job failure on RUSTSEC-2026-0006 (wasmtime advisory)
- updates yanked `bytes` 1.6.0 to 1.11.1