### PR TITLE
Update EXPIRE_AFTER_SECONDS to 2700 temporarily for Lift Off

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -4,7 +4,7 @@ use axum::http::StatusCode;
 use redis::RedisError;
 use schemars::JsonSchema;
 
-pub const EXPIRE_AFTER_SECONDS: u64 = 900; // Increasing to allow partner verifications.
+pub const EXPIRE_AFTER_SECONDS: u64 = 2700; // Increasing to allow partner verifications.
 pub const REQ_STATUS_PREFIX: &str = "req:status:";
 
 #[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize, JsonSchema)]


### PR DESCRIPTION
Increased the expiration time for partner verifications temporarily for Lift Off.