### PR TITLE
Allow RP to supply request_id on POST /request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,29 +132,8 @@ jobs:
         with:
           toolchain: stable
 
-      - name: Build bridge
-        run: cargo build --bin world-id-bridge
-
       - name: Run integration tests
         run: |
-          target/debug/world-id-bridge > bridge.log 2>&1 &
-          BRIDGE_PID=$!
-          for _ in $(seq 1 30); do
-            if curl -sf http://localhost:8000/ > /dev/null 2>&1; then break; fi
-            sleep 1
-          done
-          if ! curl -sf http://localhost:8000/ > /dev/null 2>&1; then
-            echo "bridge failed to start"
-            cat bridge.log
-            exit 1
-          fi
-          set +e
+          cargo run > bridge.log 2>&1 &
+          until curl -sf http://localhost:8000/ > /dev/null 2>&1; do sleep 1; done
           cargo test --test integration_test
-          TEST_EXIT=$?
-          set -e
-          kill "$BRIDGE_PID" 2>/dev/null || true
-          if [ "$TEST_EXIT" -ne 0 ]; then
-            echo "=== bridge.log ==="
-            cat bridge.log
-          fi
-          exit "$TEST_EXIT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,3 +104,57 @@ jobs:
         uses: EmbarkStudios/cargo-deny-action@3fd3802e88374d3fe9159b834c7714ec57d6c979 # v2.0.15 https://github.com/EmbarkStudios/cargo-deny-action/releases/tag/v2.0.15
         with:
           command: check
+
+  integration:
+    name: Integration tests
+    runs-on:
+      group: arc-public-large-amd64-runner
+
+    services:
+      redis:
+        image: redis:7
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      REDIS_URL: redis://localhost:6379
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2 https://github.com/actions/checkout/releases/tag/v4.2.2
+
+      - uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b # 2025-04-29
+        with:
+          toolchain: stable
+
+      - name: Build bridge
+        run: cargo build --bin world-id-bridge
+
+      - name: Run integration tests
+        run: |
+          target/debug/world-id-bridge > bridge.log 2>&1 &
+          BRIDGE_PID=$!
+          for _ in $(seq 1 30); do
+            if curl -sf http://localhost:8000/ > /dev/null 2>&1; then break; fi
+            sleep 1
+          done
+          if ! curl -sf http://localhost:8000/ > /dev/null 2>&1; then
+            echo "bridge failed to start"
+            cat bridge.log
+            exit 1
+          fi
+          set +e
+          cargo test --test integration_test
+          TEST_EXIT=$?
+          set -e
+          kill "$BRIDGE_PID" 2>/dev/null || true
+          if [ "$TEST_EXIT" -ne 0 ]; then
+            echo "=== bridge.log ==="
+            cat bridge.log
+          fi
+          exit "$TEST_EXIT"

--- a/src/routes/request.rs
+++ b/src/routes/request.rs
@@ -8,7 +8,7 @@ use axum::{
     Extension,
 };
 use axum_jsonschema::Json;
-use redis::{aio::ConnectionManager, AsyncCommands};
+use redis::{aio::ConnectionManager, AsyncCommands, ExistenceCheck, SetExpiry, SetOptions};
 use schemars::JsonSchema;
 use std::env;
 use std::str::FromStr;
@@ -16,15 +16,33 @@ use tower_http::cors::{AllowHeaders, Any, CorsLayer};
 use uuid::Uuid;
 
 use crate::utils::{
-    handle_redis_error, RequestPayload, RequestStatus, EXPIRE_AFTER_SECONDS, REQ_STATUS_PREFIX,
+    handle_redis_error, validate_request_id, RequestPayload, RequestStatus, EXPIRE_AFTER_SECONDS,
+    REQ_STATUS_PREFIX,
 };
 
 const REQ_PREFIX: &str = "req:";
 
+#[derive(Debug, serde::Deserialize, JsonSchema)]
+struct CreateRequestBody {
+    /// The initialization vector for the encrypted payload (opaque to the bridge).
+    iv: String,
+    /// The encrypted payload (opaque to the bridge).
+    payload: String,
+    /// Optional client-supplied `request_id`. When present, the bridge stores
+    /// the request under this key with NX semantics (409 on collision); when
+    /// absent, the bridge generates a UUID v4. Lets the RP address requests by
+    /// any opaque identifier they choose (e.g. an HKDF output) so the bridge
+    /// stays a generic content-addressable single-use store rather than baking
+    /// in any specific application's flow.
+    #[serde(default)]
+    request_id: Option<String>,
+}
+
 #[derive(Debug, serde::Serialize, JsonSchema)]
 struct RequestCreatedPayload {
-    /// The unique identifier for the request
-    request_id: Uuid,
+    /// The unique identifier for the request — the client-supplied value if
+    /// one was provided, otherwise a server-generated UUID v4.
+    request_id: String,
 }
 
 pub fn handler() -> ApiRouter {
@@ -53,9 +71,13 @@ pub fn handler() -> ApiRouter {
 }
 
 async fn has_request(
-    Path(request_id): Path<Uuid>,
+    Path(request_id): Path<String>,
     Extension(mut redis): Extension<ConnectionManager>,
 ) -> StatusCode {
+    if validate_request_id(&request_id).is_err() {
+        return StatusCode::NOT_FOUND;
+    }
+
     let Ok(exists) = redis
         .exists::<_, bool>(format!("{REQ_PREFIX}{request_id}"))
         .await
@@ -71,9 +93,15 @@ async fn has_request(
 }
 
 async fn get_request(
-    Path(request_id): Path<Uuid>,
+    Path(request_id): Path<String>,
     Extension(mut redis): Extension<ConnectionManager>,
 ) -> Result<Json<RequestPayload>, StatusCode> {
+    // Malformed IDs return 404 (same shape as missing), so the bridge doesn't
+    // leak information about its key-format expectations to callers.
+    if validate_request_id(&request_id).is_err() {
+        return Err(StatusCode::NOT_FOUND);
+    }
+
     // Use a transaction to get both status and request data atomically
     let mut pipe = redis::pipe();
     pipe.get(format!("{REQ_STATUS_PREFIX}{request_id}"))
@@ -111,49 +139,41 @@ async fn get_request(
     })
 }
 
-/// Create a new request
+/// Create a new request. Optionally accepts a client-supplied `request_id`
+/// with NX semantics; otherwise generates a UUID v4.
 async fn insert_request(
     Extension(mut redis): Extension<ConnectionManager>,
-    Json(request): Json<RequestPayload>,
+    Json(body): Json<CreateRequestBody>,
 ) -> Result<Json<RequestCreatedPayload>, StatusCode> {
-    let request_id = Uuid::new_v4();
+    let request_id = match body.request_id {
+        Some(id) => {
+            validate_request_id(&id)?;
+            id
+        }
+        None => Uuid::new_v4().to_string(),
+    };
 
     tracing::info!("Processing /request: {request_id}");
 
-    persist_request(&mut redis, request_id, &request).await?;
+    let payload = RequestPayload::new(body.iv, body.payload);
+    let payload_bytes =
+        serde_json::to_vec(&payload).map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
-    tracing::info!(
-        "{}",
-        format!("Successfully processed /request: {request_id}")
-    );
+    // SET NX on the payload — collisions return 409 in a single round trip.
+    // The status marker is set afterwards (and is idempotent under retries).
+    let options = SetOptions::default()
+        .conditional_set(ExistenceCheck::NX)
+        .with_expiration(SetExpiry::EX(EXPIRE_AFTER_SECONDS));
 
-    Ok(Json(RequestCreatedPayload { request_id }))
-}
+    let set_ok: Option<String> = redis
+        .set_options(format!("{REQ_PREFIX}{request_id}"), payload_bytes, options)
+        .await
+        .map_err(handle_redis_error)?;
 
-/// Create a new request by ID idempotently — retries succeed, even if the request exits
-/// Note: only enabled in staging
-async fn put_request(
-    Path(request_id): Path<Uuid>,
-    Extension(mut redis): Extension<ConnectionManager>,
-    Json(request): Json<RequestPayload>,
-) -> Result<StatusCode, StatusCode> {
-    tracing::info!("Processing PUT /request: {request_id}");
+    if set_ok.is_none() {
+        return Err(StatusCode::CONFLICT);
+    }
 
-    // Same logic as post, but always overwrites the existing payload, set status, and reset the TTL
-    persist_request(&mut redis, request_id, &request).await?;
-
-    tracing::info!("Successfully PUT /request: {request_id}");
-
-    Ok(StatusCode::CREATED)
-}
-
-/// Persist request payload and initialize status with TTL
-async fn persist_request(
-    redis: &mut ConnectionManager,
-    request_id: Uuid,
-    request: &RequestPayload,
-) -> Result<(), StatusCode> {
-    //ANCHOR - Set request status
     redis
         .set_ex::<_, _, ()>(
             format!("{REQ_STATUS_PREFIX}{request_id}"),
@@ -168,7 +188,37 @@ async fn persist_request(
         RequestStatus::Initialized
     );
 
-    //ANCHOR - Store payload
+    tracing::info!("Successfully processed /request: {request_id}");
+
+    Ok(Json(RequestCreatedPayload { request_id }))
+}
+
+/// Create a new request by ID idempotently — retries succeed, even if the request exists.
+/// Note: only enabled in staging.
+async fn put_request(
+    Path(request_id): Path<String>,
+    Extension(mut redis): Extension<ConnectionManager>,
+    Json(request): Json<RequestPayload>,
+) -> Result<StatusCode, StatusCode> {
+    validate_request_id(&request_id)?;
+
+    tracing::info!("Processing PUT /request: {request_id}");
+
+    // Same logic as POST, but always overwrites the existing payload, sets status, and resets the TTL.
+    redis
+        .set_ex::<_, _, ()>(
+            format!("{REQ_STATUS_PREFIX}{request_id}"),
+            RequestStatus::Initialized.to_string(),
+            EXPIRE_AFTER_SECONDS,
+        )
+        .await
+        .map_err(handle_redis_error)?;
+
+    tracing::info!(
+        "Request {request_id} state transition: new -> {}",
+        RequestStatus::Initialized
+    );
+
     redis
         .set_ex::<_, _, ()>(
             format!("{REQ_PREFIX}{request_id}"),
@@ -178,5 +228,7 @@ async fn persist_request(
         .await
         .map_err(handle_redis_error)?;
 
-    Ok(())
+    tracing::info!("Successfully PUT /request: {request_id}");
+
+    Ok(StatusCode::CREATED)
 }

--- a/src/routes/request.rs
+++ b/src/routes/request.rs
@@ -34,6 +34,15 @@ struct CreateRequestBody {
     /// any opaque identifier they choose (e.g. an HKDF output) so the bridge
     /// stays a generic content-addressable single-use store rather than baking
     /// in any specific application's flow.
+    ///
+    /// **Entropy is the RP's responsibility.** The bridge enforces length
+    /// bounds and a charset (see `validate_request_id`) but does not check
+    /// cryptographic randomness. A predictable identifier lets a third party
+    /// GETDEL the request before the legitimate consumer does — confidentiality
+    /// still holds because the payload is encrypted, but the single-use
+    /// guarantee is broken. RPs should use a high-entropy source (UUID v4,
+    /// HKDF output, etc.). TODO: enforce a stronger guarantee at the protocol
+    /// layer — e.g. a server-mixed nonce — once we have a clear story for it.
     #[serde(default)]
     request_id: Option<String>,
 }
@@ -75,7 +84,7 @@ async fn has_request(
     Extension(mut redis): Extension<ConnectionManager>,
 ) -> StatusCode {
     if validate_request_id(&request_id).is_err() {
-        return StatusCode::NOT_FOUND;
+        return StatusCode::BAD_REQUEST;
     }
 
     let Ok(exists) = redis
@@ -96,10 +105,8 @@ async fn get_request(
     Path(request_id): Path<String>,
     Extension(mut redis): Extension<ConnectionManager>,
 ) -> Result<Json<RequestPayload>, StatusCode> {
-    // Malformed IDs return 404 (same shape as missing), so the bridge doesn't
-    // leak information about its key-format expectations to callers.
     if validate_request_id(&request_id).is_err() {
-        return Err(StatusCode::NOT_FOUND);
+        return Err(StatusCode::BAD_REQUEST);
     }
 
     // Use a transaction to get both status and request data atomically
@@ -160,7 +167,6 @@ async fn insert_request(
         serde_json::to_vec(&payload).map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
     // SET NX on the payload — collisions return 409 in a single round trip.
-    // The status marker is set afterwards (and is idempotent under retries).
     let options = SetOptions::default()
         .conditional_set(ExistenceCheck::NX)
         .with_expiration(SetExpiry::EX(EXPIRE_AFTER_SECONDS));

--- a/src/routes/response.rs
+++ b/src/routes/response.rs
@@ -57,7 +57,7 @@ async fn get_response(
     Extension(mut redis): Extension<ConnectionManager>,
 ) -> Result<Json<Response>, StatusCode> {
     if validate_request_id(&request_id).is_err() {
-        return Err(StatusCode::NOT_FOUND);
+        return Err(StatusCode::BAD_REQUEST);
     }
 
     // Use a transaction to get both status and response atomically
@@ -125,7 +125,7 @@ async fn has_response_status(
     Extension(mut redis): Extension<ConnectionManager>,
 ) -> StatusCode {
     if validate_request_id(&request_id).is_err() {
-        return StatusCode::NOT_FOUND;
+        return StatusCode::BAD_REQUEST;
     }
 
     let Ok(exists) = redis

--- a/src/routes/response.rs
+++ b/src/routes/response.rs
@@ -17,7 +17,8 @@ use tower_http::cors::{AllowHeaders, Any, CorsLayer};
 use uuid::Uuid;
 
 use crate::utils::{
-    handle_redis_error, RequestPayload, RequestStatus, EXPIRE_AFTER_SECONDS, REQ_STATUS_PREFIX,
+    handle_redis_error, validate_request_id, RequestPayload, RequestStatus, EXPIRE_AFTER_SECONDS,
+    REQ_STATUS_PREFIX,
 };
 
 const RES_PREFIX: &str = "res:";
@@ -31,7 +32,7 @@ struct Response {
 #[derive(Debug, serde::Serialize, JsonSchema)]
 struct ResponseCreatedPayload {
     /// The unique identifier for the response
-    request_id: Uuid,
+    request_id: String,
 }
 
 pub fn handler() -> ApiRouter {
@@ -52,9 +53,13 @@ pub fn handler() -> ApiRouter {
 }
 
 async fn get_response(
-    Path(request_id): Path<Uuid>,
+    Path(request_id): Path<String>,
     Extension(mut redis): Extension<ConnectionManager>,
 ) -> Result<Json<Response>, StatusCode> {
+    if validate_request_id(&request_id).is_err() {
+        return Err(StatusCode::NOT_FOUND);
+    }
+
     // Use a transaction to get both status and response atomically
     let mut pipe = redis::pipe();
     pipe.get(format!("{REQ_STATUS_PREFIX}{request_id}"))
@@ -116,9 +121,13 @@ async fn get_response(
 }
 
 async fn has_response_status(
-    Path(request_id): Path<Uuid>,
+    Path(request_id): Path<String>,
     Extension(mut redis): Extension<ConnectionManager>,
 ) -> StatusCode {
+    if validate_request_id(&request_id).is_err() {
+        return StatusCode::NOT_FOUND;
+    }
+
     let Ok(exists) = redis
         .exists::<_, bool>(format!("{REQ_STATUS_PREFIX}{request_id}"))
         .await
@@ -134,10 +143,12 @@ async fn has_response_status(
 }
 
 async fn insert_response(
-    Path(request_id): Path<Uuid>,
+    Path(request_id): Path<String>,
     Extension(mut redis): Extension<ConnectionManager>,
     Json(request): Json<RequestPayload>,
 ) -> Result<StatusCode, StatusCode> {
+    validate_request_id(&request_id)?;
+
     //ANCHOR - Check the request is valid
     let current_status = redis
         .get::<_, Option<String>>(format!("{REQ_STATUS_PREFIX}{request_id}"))
@@ -188,7 +199,7 @@ async fn create_response(
     Extension(mut redis): Extension<ConnectionManager>,
     Json(request): Json<RequestPayload>,
 ) -> Result<(StatusCode, Json<ResponseCreatedPayload>), StatusCode> {
-    let request_id = Uuid::new_v4();
+    let request_id = Uuid::new_v4().to_string();
 
     tracing::info!("Processing POST /response: {request_id}");
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -7,6 +7,12 @@ use schemars::JsonSchema;
 pub const EXPIRE_AFTER_SECONDS: u64 = 900; // Increasing to allow partner verifications.
 pub const REQ_STATUS_PREFIX: &str = "req:status:";
 
+/// Maximum length of a `request_id`, whether supplied by the client on
+/// `POST /request` or extracted from a route path. Bounds Redis-key memory and
+/// keeps URLs reasonable; 256 is more than enough for UUIDs (36), HKDF-derived
+/// hex (64), and base64-shaped identifiers.
+pub const REQUEST_ID_MAX_LEN: usize = 256;
+
 #[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 pub enum RequestStatus {
@@ -49,8 +55,32 @@ pub struct RequestPayload {
     payload: String,
 }
 
+impl RequestPayload {
+    pub const fn new(iv: String, payload: String) -> Self {
+        Self { iv, payload }
+    }
+}
+
 #[allow(clippy::needless_pass_by_value)]
 pub fn handle_redis_error(e: RedisError) -> StatusCode {
     tracing::error!("Redis error: {e}");
     StatusCode::INTERNAL_SERVER_ERROR
+}
+
+/// Validate a `request_id` (path param or client-supplied body field):
+/// non-empty, at most `REQUEST_ID_MAX_LEN` chars, charset limited to
+/// URL-path-safe ASCII (alphanumeric plus `-`, `_`, `.`, `:`). Anything outside
+/// this set is rejected so clients can't smuggle path separators or other
+/// characters that would interact badly with Redis-key formatting or routing.
+pub fn validate_request_id(id: &str) -> Result<(), StatusCode> {
+    if id.is_empty() || id.len() > REQUEST_ID_MAX_LEN {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+    if !id
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.' | ':'))
+    {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+    Ok(())
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -13,6 +13,14 @@ pub const REQ_STATUS_PREFIX: &str = "req:status:";
 /// hex (64), and base64-shaped identifiers.
 pub const REQUEST_ID_MAX_LEN: usize = 256;
 
+/// Minimum length of a `request_id`. Anything shorter is almost certainly a
+/// mistake — UUIDs are 36 chars, UUID-simple is 32, HKDF-derived hex is 64,
+/// and base64url of 12 random bytes is 16. The bound doesn't enforce
+/// cryptographic entropy on its own (a 16-char string of `aaaa…` passes),
+/// but it stops trivial typos and obvious attacks; the RP is responsible
+/// for picking high-entropy identifiers.
+pub const REQUEST_ID_MIN_LEN: usize = 16;
+
 #[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 pub enum RequestStatus {
@@ -68,17 +76,21 @@ pub fn handle_redis_error(e: RedisError) -> StatusCode {
 }
 
 /// Validate a `request_id` (path param or client-supplied body field):
-/// non-empty, at most `REQUEST_ID_MAX_LEN` chars, charset limited to
-/// URL-path-safe ASCII (alphanumeric plus `-`, `_`, `.`, `:`). Anything outside
-/// this set is rejected so clients can't smuggle path separators or other
-/// characters that would interact badly with Redis-key formatting or routing.
+/// length between `REQUEST_ID_MIN_LEN` and `REQUEST_ID_MAX_LEN`, charset
+/// limited to URL-path-safe ASCII (alphanumeric plus `-`, `_`, `.`).
+///
+/// `:` is intentionally excluded from the charset: an ID like `status:foo`
+/// would round-trip into the Redis key `req:status:foo`, colliding with the
+/// status-namespace key `req:status:foo` that the bridge writes for some
+/// other request. Keeping the charset disjoint from the literal `:` prevents
+/// that overlap by construction.
 pub fn validate_request_id(id: &str) -> Result<(), StatusCode> {
-    if id.is_empty() || id.len() > REQUEST_ID_MAX_LEN {
+    if id.len() < REQUEST_ID_MIN_LEN || id.len() > REQUEST_ID_MAX_LEN {
         return Err(StatusCode::BAD_REQUEST);
     }
     if !id
         .chars()
-        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.' | ':'))
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.'))
     {
         return Err(StatusCode::BAD_REQUEST);
     }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -2,6 +2,7 @@ use curl::easy::{Easy, List};
 use serde_json::{json, Value};
 use std::env;
 use std::io::Read;
+use uuid::Uuid;
 
 /// Helper to get the base URL for the wallet bridge service
 fn get_base_url() -> String {
@@ -349,6 +350,94 @@ fn test_create_request_validation() {
     let (status_code, _) = http_post(&url, &invalid_payload);
 
     assert!(status_code >= 400 && status_code < 500);
+}
+
+// ---------------------------------------------------------------------------
+// Client-supplied request_id (POST /request optional `request_id` field).
+// Lets the RP address requests by any opaque ID it chooses (e.g. an HKDF
+// output) so the bridge can be used as a generic content-addressable
+// single-use store without the bridge needing to know the RP's key-derivation
+// scheme.
+// ---------------------------------------------------------------------------
+
+fn fresh_id() -> String {
+    format!("{}{}", Uuid::new_v4().simple(), Uuid::new_v4().simple())
+}
+
+#[test]
+fn test_create_request_with_client_supplied_id() {
+    let base_url = get_base_url();
+    let id = fresh_id();
+    let body = json!({
+        "request_id": id,
+        "iv": "iv-for-custom-id",
+        "payload": "payload-for-custom-id",
+    });
+    let (s, b) = http_post(&format!("{base_url}/request"), &body);
+    assert_eq!(s, 200, "POST /request with custom id should succeed: {b}");
+    let v: Value = serde_json::from_str(&b).unwrap();
+    assert_eq!(v["request_id"], id, "response echoes the supplied id");
+
+    let (gs, gb) = http_get(&format!("{base_url}/request/{id}"));
+    assert_eq!(gs, 200, "GET /request/<custom> should retrieve the payload");
+    let gv: Value = serde_json::from_str(&gb).unwrap();
+    assert_eq!(gv["iv"], "iv-for-custom-id");
+    assert_eq!(gv["payload"], "payload-for-custom-id");
+
+    // GETDEL semantics — second GET 404s.
+    let (gs2, _) = http_get(&format!("{base_url}/request/{id}"));
+    assert_eq!(gs2, 404);
+}
+
+#[test]
+fn test_create_request_with_duplicate_id_returns_409() {
+    let base_url = get_base_url();
+    let id = fresh_id();
+    let body = json!({"request_id": id, "iv": "x", "payload": "y"});
+
+    let (s1, _) = http_post(&format!("{base_url}/request"), &body);
+    assert_eq!(s1, 200);
+
+    let (s2, _) = http_post(&format!("{base_url}/request"), &body);
+    assert_eq!(s2, 409, "second POST with same request_id must 409");
+}
+
+#[test]
+fn test_create_request_without_id_still_generates_uuid() {
+    let base_url = get_base_url();
+    let body = json!({"iv": "no-id-iv", "payload": "no-id-payload"});
+
+    let (s, b) = http_post(&format!("{base_url}/request"), &body);
+    assert_eq!(s, 200);
+    let v: Value = serde_json::from_str(&b).unwrap();
+    let id = v["request_id"].as_str().expect("request_id");
+    // Auto-generated IDs are UUID v4 — 36 chars with hyphens.
+    assert_eq!(id.len(), 36, "auto-generated id should be a UUID v4: {id}");
+    assert_eq!(id.matches('-').count(), 4);
+}
+
+#[test]
+fn test_create_request_rejects_invalid_request_id_chars() {
+    let base_url = get_base_url();
+    let body = json!({
+        "request_id": "has spaces and / slashes",
+        "iv": "x",
+        "payload": "y",
+    });
+    let (s, _) = http_post(&format!("{base_url}/request"), &body);
+    assert_eq!(s, 400, "invalid request_id chars must 400");
+}
+
+#[test]
+fn test_create_request_rejects_too_long_request_id() {
+    let base_url = get_base_url();
+    let body = json!({
+        "request_id": "a".repeat(257),
+        "iv": "x",
+        "payload": "y",
+    });
+    let (s, _) = http_post(&format!("{base_url}/request"), &body);
+    assert_eq!(s, 400, "request_id over 256 chars must 400");
 }
 
 /// Test OpenAPI documentation endpoint exists

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -440,6 +440,41 @@ fn test_create_request_rejects_too_long_request_id() {
     assert_eq!(s, 400, "request_id over 256 chars must 400");
 }
 
+#[test]
+fn test_create_request_rejects_too_short_request_id() {
+    let base_url = get_base_url();
+    let body = json!({
+        "request_id": "shortid",
+        "iv": "x",
+        "payload": "y",
+    });
+    let (s, _) = http_post(&format!("{base_url}/request"), &body);
+    assert_eq!(s, 400, "request_id under 16 chars must 400");
+}
+
+#[test]
+fn test_create_request_rejects_colon_in_request_id() {
+    // Colon is excluded from the charset — `status:foo` would round-trip into
+    // the Redis key `req:status:foo`, colliding with the bridge's own status
+    // namespace. Excluding `:` prevents the overlap by construction.
+    let base_url = get_base_url();
+    let body = json!({
+        "request_id": "status:colliding-id-here",
+        "iv": "x",
+        "payload": "y",
+    });
+    let (s, _) = http_post(&format!("{base_url}/request"), &body);
+    assert_eq!(s, 400, "request_id containing `:` must 400");
+}
+
+#[test]
+fn test_get_request_malformed_path_returns_400() {
+    let base_url = get_base_url();
+    // 3-char path param fails the min-length check.
+    let (s, _) = http_get(&format!("{base_url}/request/abc"));
+    assert_eq!(s, 400, "GET /request/<too-short> must 400, not 404");
+}
+
 /// Test OpenAPI documentation endpoint exists
 #[test]
 fn test_openapi_endpoint() {


### PR DESCRIPTION
## Summary

Lets the RP optionally supply a `request_id` on `POST /request` and relaxes the `request_id` path param from `Uuid` to `String`, turning the bridge into a generic content-addressable single-use store keyed by any opaque identifier the caller chooses.

- `POST /request` accepts an optional `request_id` field. When present, the bridge stores under this key with **SET NX** semantics (409 on collision). When absent, behavior is unchanged — server-generated UUID v4. Response shape is the same `{ request_id }`.
- `request_id` path params on `GET/HEAD /request/:id`, `PUT /request/:id` (staging), and `GET/HEAD/PUT /response/:id` are now `String`. Bounded to 256 chars and a URL-path-safe charset (`[A-Za-z0-9._:-]`) via the new `validate_request_id` helper. Malformed IDs return 404 on GETs (same shape as missing) and 400 on POST/PUT.

## Test plan

- [x] `cargo fmt -- --check` clean
- [x] `cargo clippy --all-features` clean (pedantic + nursery)
- [x] `cargo test --test integration_test` — 17/17 pass against a real Redis container. Coverage:
  - happy-path round trip with a client-supplied `request_id` (POST → GET → GETDEL second GET = 404)
  - duplicate `request_id` returns 409
  - omitting `request_id` still generates a UUID v4
  - invalid charset in `request_id` returns 400
  - `request_id` over 256 chars returns 400
  - all 12 pre-existing legacy tests still pass
- [ ] CI green on `x86_64-unknown-linux-musl` (this PR adds an `integration` job to CI so the suite actually runs there)

## Commits

1. **Allow RP to supply request_id on POST /request** — the bridge change
2. **ci: add integration-test job** — runs the suite in CI behind a Redis service

🤖 Generated with [Claude Code](https://claude.com/claude-code)