### PR TITLE
Gate GET /response/:id on session_nonce (code-variant)

### DIFF
--- a/src/routes/request.rs
+++ b/src/routes/request.rs
@@ -20,7 +20,7 @@ use uuid::Uuid;
 use crate::utils::{
     code_ttl_seconds, handle_redis_error, invite_code_flow_enabled, random_token, sha256_hex,
     validate_base64, RequestPayload, RequestStatus, CODE_IDX_PREFIX, EXPIRE_AFTER_SECONDS,
-    REQ_STATUS_PREFIX,
+    REQ_NONCE_PREFIX, REQ_STATUS_PREFIX,
 };
 
 const REQ_PREFIX: &str = "req:";
@@ -224,6 +224,17 @@ async fn insert_code_request(
         .set_ex::<_, _, ()>(
             format!("{REQ_STATUS_PREFIX}{request_id}"),
             RequestStatus::Initialized.to_string(),
+            EXPIRE_AFTER_SECONDS,
+        )
+        .await
+        .map_err(handle_redis_error)?;
+
+    // Mirror the session_nonce hash to a key addressable by `request_id` so
+    // `GET /response/:request_id` can gate on it without needing the index.
+    redis
+        .set_ex::<_, _, ()>(
+            format!("{REQ_NONCE_PREFIX}{request_id}"),
+            &session_nonce_hash,
             EXPIRE_AFTER_SECONDS,
         )
         .await

--- a/src/routes/response.rs
+++ b/src/routes/response.rs
@@ -6,7 +6,7 @@ use aide::axum::{
 };
 use axum::{
     extract::Path,
-    http::{Method, StatusCode},
+    http::{HeaderMap, Method, StatusCode},
     Extension,
 };
 use axum_jsonschema::Json;
@@ -17,8 +17,11 @@ use tower_http::cors::{AllowHeaders, Any, CorsLayer};
 use uuid::Uuid;
 
 use crate::utils::{
-    handle_redis_error, RequestPayload, RequestStatus, EXPIRE_AFTER_SECONDS, REQ_STATUS_PREFIX,
+    constant_time_eq, handle_redis_error, sha256_hex, RequestPayload, RequestStatus,
+    EXPIRE_AFTER_SECONDS, REQ_NONCE_PREFIX, REQ_STATUS_PREFIX,
 };
+
+const SESSION_NONCE_HEADER: &str = "x-session-nonce";
 
 const RES_PREFIX: &str = "res:";
 
@@ -51,10 +54,72 @@ pub fn handler() -> ApiRouter {
         .api_route("/response", post(create_response).layer(cors))
 }
 
+/// Code-variant gate: if a `session_nonce` hash is stored for this `request_id`,
+/// require an `X-Session-Nonce` header whose SHA-256 matches it. Legacy
+/// (non-code-variant) requests have no such row and are unaffected.
+///
+/// On success, returns the stored hash (or `None` for legacy requests) so
+/// the caller can decide whether to clean up the gate row after consumption.
+async fn enforce_session_nonce_gate(
+    request_id: &Uuid,
+    headers: &HeaderMap,
+    redis: &mut ConnectionManager,
+) -> Result<Option<String>, StatusCode> {
+    let stored: Option<String> = redis
+        .get(format!("{REQ_NONCE_PREFIX}{request_id}"))
+        .await
+        .map_err(handle_redis_error)?;
+
+    if let Some(stored_hash) = stored.as_deref() {
+        let presented = headers
+            .get(SESSION_NONCE_HEADER)
+            .and_then(|h| h.to_str().ok())
+            .ok_or(StatusCode::UNAUTHORIZED)?;
+        let presented_hash = sha256_hex(presented);
+        if !constant_time_eq(presented_hash.as_bytes(), stored_hash.as_bytes()) {
+            return Err(StatusCode::UNAUTHORIZED);
+        }
+    }
+
+    Ok(stored)
+}
+
+/// Best-effort cleanup of bookkeeping rows after a response has been
+/// successfully retrieved. Failures are logged but never propagated; both keys
+/// have a TTL fallback.
+async fn cleanup_after_consumption(
+    request_id: &Uuid,
+    delete_nonce: bool,
+    redis: &mut ConnectionManager,
+) {
+    if let Err(e) = redis
+        .del::<_, ()>(format!("{REQ_STATUS_PREFIX}{request_id}"))
+        .await
+    {
+        tracing::warn!("Failed to delete status for {request_id} after response retrieval: {e}");
+    }
+
+    if delete_nonce {
+        if let Err(e) = redis
+            .del::<_, ()>(format!("{REQ_NONCE_PREFIX}{request_id}"))
+            .await
+        {
+            tracing::warn!(
+                "Failed to delete session nonce hash for {request_id} after response retrieval: {e}"
+            );
+        }
+    }
+}
+
 async fn get_response(
     Path(request_id): Path<Uuid>,
+    headers: HeaderMap,
     Extension(mut redis): Extension<ConnectionManager>,
 ) -> Result<Json<Response>, StatusCode> {
+    // Returns Some(stored_hash) for code-variant requests (gate fired and passed)
+    // and None for legacy requests (no gate to fire).
+    let stored_nonce_hash = enforce_session_nonce_gate(&request_id, &headers, &mut redis).await?;
+
     // Use a transaction to get both status and response atomically
     let mut pipe = redis::pipe();
     pipe.get(format!("{REQ_STATUS_PREFIX}{request_id}"))
@@ -76,16 +141,7 @@ async fn get_response(
             RequestStatus::Completed
         );
 
-        // Best-effort status cleanup (will expire via TTL anyway)
-        // Don't propagate errors to avoid losing response data if status delete fails
-        if let Err(e) = redis
-            .del::<_, ()>(format!("{REQ_STATUS_PREFIX}{request_id}"))
-            .await
-        {
-            tracing::warn!(
-                "Failed to delete status for {request_id} after response retrieval: {e}"
-            );
-        }
+        cleanup_after_consumption(&request_id, stored_nonce_hash.is_some(), &mut redis).await;
 
         return serde_json::from_slice(&value).map_or(
             Err(StatusCode::INTERNAL_SERVER_ERROR),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -9,6 +9,7 @@ use sha2::{Digest, Sha256};
 
 pub const EXPIRE_AFTER_SECONDS: u64 = 900; // Increasing to allow partner verifications.
 pub const REQ_STATUS_PREFIX: &str = "req:status:";
+pub const REQ_NONCE_PREFIX: &str = "req:nonce:";
 pub const CODE_IDX_PREFIX: &str = "code:idx:";
 
 const DEFAULT_CODE_TTL_SECONDS: u64 = 600;
@@ -105,6 +106,20 @@ pub fn sha256_hex(input: &str) -> String {
     let mut hasher = Sha256::new();
     hasher.update(input.as_bytes());
     format!("{:x}", hasher.finalize())
+}
+
+/// Constant-time byte-slice equality. Used to compare a presented session
+/// nonce's SHA-256 hash against the stored hash without leaking match-prefix
+/// length through timing.
+pub fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff: u8 = 0;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
 }
 
 /// Reject inputs that don't look like standard base64 of plausible length.

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -13,8 +13,21 @@ fn get_base_url() -> String {
 
 /// Helper to perform a GET request and return (status_code, body)
 fn http_get(url: &str) -> (u32, String) {
+    http_get_with_headers(url, &[])
+}
+
+/// Helper to perform a GET request with extra headers (`name: value` pairs).
+fn http_get_with_headers(url: &str, extra_headers: &[(&str, &str)]) -> (u32, String) {
     let mut easy = Easy::new();
     easy.url(url).unwrap();
+
+    if !extra_headers.is_empty() {
+        let mut headers = List::new();
+        for (k, v) in extra_headers {
+            headers.append(&format!("{k}: {v}")).unwrap();
+        }
+        easy.http_headers(headers).unwrap();
+    }
 
     let mut response_body = Vec::new();
     {
@@ -629,6 +642,126 @@ fn test_code_expires_after_ttl() {
         &json!({"index": index}),
     );
     assert_eq!(rs, 404, "expired code must redeem to 404");
+}
+
+// ---------------------------------------------------------------------------
+// Session-nonce gate on GET /response/:request_id (code-variant only).
+// ---------------------------------------------------------------------------
+
+/// Helper: create a code-variant request, returning (request_id, session_nonce).
+fn create_code_request(base_url: &str) -> (String, String) {
+    let body = json!({
+        "request_code_enabled": true,
+        "index": fresh_index(),
+        "iv": fresh_b64(12),
+        "payload": fresh_b64(64),
+    });
+    let (s, b) = http_post(&format!("{base_url}/request"), &body);
+    assert_eq!(s, 200, "code POST /request should succeed: {b}");
+    let v: Value = serde_json::from_str(&b).unwrap();
+    (
+        v["request_id"].as_str().unwrap().to_string(),
+        v["session_nonce"].as_str().unwrap().to_string(),
+    )
+}
+
+#[test]
+fn test_code_response_gate_rejects_missing_header() {
+    let base_url = get_base_url();
+    let (request_id, _nonce) = create_code_request(&base_url);
+
+    let (s, _) = http_get(&format!("{base_url}/response/{request_id}"));
+    assert_eq!(
+        s, 401,
+        "GET /response without X-Session-Nonce on a code-variant request must 401"
+    );
+}
+
+#[test]
+fn test_code_response_gate_rejects_wrong_nonce() {
+    let base_url = get_base_url();
+    let (request_id, _nonce) = create_code_request(&base_url);
+
+    let (s, _) = http_get_with_headers(
+        &format!("{base_url}/response/{request_id}"),
+        &[("X-Session-Nonce", "this-is-not-the-right-nonce")],
+    );
+    assert_eq!(s, 401, "GET /response with wrong nonce must 401");
+}
+
+#[test]
+fn test_code_response_gate_accepts_correct_nonce_pre_response() {
+    let base_url = get_base_url();
+    let (request_id, nonce) = create_code_request(&base_url);
+
+    // Before any PUT /response, a correctly-authenticated GET should return the
+    // current status with response: None (and NOT 401, NOT 404).
+    let (s, b) = http_get_with_headers(
+        &format!("{base_url}/response/{request_id}"),
+        &[("X-Session-Nonce", &nonce)],
+    );
+    assert_eq!(
+        s, 200,
+        "GET /response with correct nonce should succeed: {b}"
+    );
+    let v: Value = serde_json::from_str(&b).unwrap();
+    assert!(v["response"].is_null(), "response should be null pre-PUT");
+    assert_eq!(v["status"], "initialized");
+}
+
+#[test]
+fn test_code_response_gate_full_round_trip() {
+    let base_url = get_base_url();
+    let (request_id, nonce) = create_code_request(&base_url);
+
+    let resp_iv = fresh_b64(12);
+    let resp_payload = fresh_b64(64);
+    let (ps, _) = http_put(
+        &format!("{base_url}/response/{request_id}"),
+        &json!({"iv": resp_iv, "payload": resp_payload}),
+    );
+    assert_eq!(ps, 201, "PUT /response should succeed");
+
+    let (gs, gb) = http_get_with_headers(
+        &format!("{base_url}/response/{request_id}"),
+        &[("X-Session-Nonce", &nonce)],
+    );
+    assert_eq!(gs, 200, "GET /response with correct nonce should succeed");
+    let v: Value = serde_json::from_str(&gb).unwrap();
+    assert_eq!(v["status"], "completed");
+    assert_eq!(v["response"]["iv"], resp_iv);
+    assert_eq!(v["response"]["payload"], resp_payload);
+
+    // After consumption, the nonce key is also gone — a second GET (with the
+    // same correct nonce) now sees a "legacy-shape" lookup and 404s rather than
+    // 401ing, since the gate only fires when the nonce row exists.
+    let (gs2, _) = http_get_with_headers(
+        &format!("{base_url}/response/{request_id}"),
+        &[("X-Session-Nonce", &nonce)],
+    );
+    assert_eq!(gs2, 404, "second GET should 404 (consumed)");
+}
+
+#[test]
+fn test_legacy_get_response_unaffected_by_gate() {
+    let base_url = get_base_url();
+    // Legacy POST /request has no session_nonce, so its req:nonce row is never
+    // written; GET /response should behave as before (no header required).
+    let body = json!({
+        "iv": fresh_b64(12),
+        "payload": fresh_b64(64),
+    });
+    let (s, b) = http_post(&format!("{base_url}/request"), &body);
+    assert_eq!(s, 200);
+    let v: Value = serde_json::from_str(&b).unwrap();
+    let request_id = v["request_id"].as_str().unwrap().to_string();
+
+    // No header — legacy flow should still answer.
+    let (gs, _) = http_get(&format!("{base_url}/response/{request_id}"));
+    assert_eq!(
+        gs, 200,
+        "legacy GET /response without header must continue to work"
+    );
 }
 
 /// Test OpenAPI documentation endpoint exists


### PR DESCRIPTION
## Summary

- Stacked on #89. Implements the `session_nonce` gate on `GET /response/:request_id` that the original WDP-73 spec called for and that #89 explicitly deferred.
- Without this gate, anyone who learned a `request_id` could pull the encrypted response from Bridge. Confidentiality still held (the blob is encrypted with `K`, which only the legitimate RP and World App possess), but the spec's "RP-authentication" property did not.

## How it works

- On code-variant `POST /request`, in addition to writing `session_nonce_hash` into the existing `code:idx:<index>` Redis hash, mirror it into a new `req:nonce:<request_id>` key with the same TTL. This makes the hash addressable by the `request_id` the RP polls on (it doesn't have the `index` after creation).
- `GET /response/:request_id` first checks for that key. Presence ⇒ code-variant request ⇒ require an `X-Session-Nonce` header, SHA-256 it, **constant-time** compare against the stored hash. Mismatch or missing header → `401`.
- After a successful response retrieval, the nonce key is best-effort deleted alongside the status key (TTL fallback either way).
- Legacy (non-code-variant) requests never write a `req:nonce:` row, so the gate is a no-op for them.

## What's NOT in this PR

- Rate limiting on `/code/redeem` — still tracked in [APP-9426](https://linear.app/worldcoin/issue/APP-9426). Next stacked PR.

## Test plan

- [x] `cargo clippy --all-features --tests` clean (pedantic + nursery; required extracting `enforce_session_nonce_gate` and `cleanup_after_consumption` to keep `get_response` under cognitive-complexity threshold)
- [x] `CODE_TTL_SECONDS=2 cargo test --test integration_test` — 27/27 pass against a real Redis container. New tests:
  - `test_code_response_gate_rejects_missing_header` — 401 when no header
  - `test_code_response_gate_rejects_wrong_nonce` — 401 on mismatched nonce
  - `test_code_response_gate_accepts_correct_nonce_pre_response` — 200 with `response: None` while waiting
  - `test_code_response_gate_full_round_trip` — full round-trip including post-consumption 404
  - `test_legacy_get_response_unaffected_by_gate` — legacy flow unchanged
- [ ] CI green on `x86_64-unknown-linux-musl`
- [ ] Manual smoke test in staging once #89 + APP-9426 land and IDKit / World App are wired up E2E (RP needs to send the `X-Session-Nonce` header it received from `POST /request`)

## Security checklist

- [x] Constant-time compare on the SHA-256 hashes (`utils::constant_time_eq`) — no dep added; inputs are uniformly distributed so even non-CT compare would leak little, but right primitive is cheap and audit-friendly
- [x] Raw `session_nonce` never logged; only stored as SHA-256 hex
- [x] Mismatch and missing-header both return the same 401 (no oracle on whether the request_id is code-variant vs. legacy — but note that absence of gate on legacy flow does mean a *valid* nonce-less response on legacy ⇒ caller can infer it's legacy. This is fine since legacy is a separate, public-by-design pathway; flagging here for completeness.)

## Client-side impact

After this lands, the IDKit RP poll loop must include the `X-Session-Nonce` header (the value it got back from `POST /request` for code-variant requests). RPs polling without it will start seeing 401s. Coordinate the merge with the IDKit-side change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)