### PR TITLE
Fix case-sensitive request_id lookups

### DIFF
--- a/src/routes/request.rs
+++ b/src/routes/request.rs
@@ -83,6 +83,7 @@ async fn has_request(
     Path(request_id): Path<String>,
     Extension(mut redis): Extension<ConnectionManager>,
 ) -> StatusCode {
+    let request_id = request_id.to_lowercase();
     if validate_request_id(&request_id).is_err() {
         return StatusCode::BAD_REQUEST;
     }
@@ -105,6 +106,7 @@ async fn get_request(
     Path(request_id): Path<String>,
     Extension(mut redis): Extension<ConnectionManager>,
 ) -> Result<Json<RequestPayload>, StatusCode> {
+    let request_id = request_id.to_lowercase();
     if validate_request_id(&request_id).is_err() {
         return Err(StatusCode::BAD_REQUEST);
     }
@@ -154,6 +156,7 @@ async fn insert_request(
 ) -> Result<Json<RequestCreatedPayload>, StatusCode> {
     let request_id = match body.request_id {
         Some(id) => {
+            let id = id.to_lowercase();
             validate_request_id(&id)?;
             id
         }
@@ -206,6 +209,7 @@ async fn put_request(
     Extension(mut redis): Extension<ConnectionManager>,
     Json(request): Json<RequestPayload>,
 ) -> Result<StatusCode, StatusCode> {
+    let request_id = request_id.to_lowercase();
     validate_request_id(&request_id)?;
 
     tracing::info!("Processing PUT /request: {request_id}");

--- a/src/routes/response.rs
+++ b/src/routes/response.rs
@@ -56,6 +56,7 @@ async fn get_response(
     Path(request_id): Path<String>,
     Extension(mut redis): Extension<ConnectionManager>,
 ) -> Result<Json<Response>, StatusCode> {
+    let request_id = request_id.to_lowercase();
     if validate_request_id(&request_id).is_err() {
         return Err(StatusCode::BAD_REQUEST);
     }
@@ -124,6 +125,7 @@ async fn has_response_status(
     Path(request_id): Path<String>,
     Extension(mut redis): Extension<ConnectionManager>,
 ) -> StatusCode {
+    let request_id = request_id.to_lowercase();
     if validate_request_id(&request_id).is_err() {
         return StatusCode::BAD_REQUEST;
     }
@@ -147,6 +149,7 @@ async fn insert_response(
     Extension(mut redis): Extension<ConnectionManager>,
     Json(request): Json<RequestPayload>,
 ) -> Result<StatusCode, StatusCode> {
+    let request_id = request_id.to_lowercase();
     validate_request_id(&request_id)?;
 
     //ANCHOR - Check the request is valid

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -475,6 +475,93 @@ fn test_get_request_malformed_path_returns_400() {
     assert_eq!(s, 400, "GET /request/<too-short> must 400, not 404");
 }
 
+// ---------------------------------------------------------------------------
+// request_id case-insensitivity: all IDs are normalized to lowercase so
+// callers using mixed-case or uppercase IDs always hit the same Redis key.
+// ---------------------------------------------------------------------------
+
+/// Supplying an uppercase `request_id` on POST /request — the response echoes
+/// it back as lowercase and the key is stored lowercase.
+#[test]
+fn test_create_request_uppercase_id_is_normalized() {
+    let base_url = get_base_url();
+    let id_lower = fresh_id();
+    let id_upper = id_lower.to_uppercase();
+
+    let body = json!({"request_id": id_upper, "iv": "iv-upper", "payload": "payload-upper"});
+    let (s, b) = http_post(&format!("{base_url}/request"), &body);
+    assert_eq!(s, 200, "POST with uppercase request_id should succeed: {b}");
+
+    let v: Value = serde_json::from_str(&b).unwrap();
+    assert_eq!(
+        v["request_id"], id_lower,
+        "response must echo the normalized (lowercase) id"
+    );
+
+    // Retrieve using the lowercase id — must find the stored payload.
+    let (gs, gb) = http_get(&format!("{base_url}/request/{id_lower}"));
+    assert_eq!(gs, 200, "GET with lowercase id must find the payload");
+    let gv: Value = serde_json::from_str(&gb).unwrap();
+    assert_eq!(gv["iv"], "iv-upper");
+}
+
+/// GET /request/:id with an uppercase path param finds the key stored by its
+/// lowercase equivalent (normalization happens at the path layer too).
+#[test]
+fn test_get_request_uppercase_path_param_is_normalized() {
+    let base_url = get_base_url();
+    let id_lower = fresh_id();
+
+    // Store using lowercase id.
+    let body = json!({"request_id": id_lower, "iv": "iv-path", "payload": "payload-path"});
+    let (s, _) = http_post(&format!("{base_url}/request"), &body);
+    assert_eq!(s, 200);
+
+    // Retrieve using uppercase path param — must hit the same key.
+    let id_upper = id_lower.to_uppercase();
+    let (gs, gb) = http_get(&format!("{base_url}/request/{id_upper}"));
+    assert_eq!(
+        gs, 200,
+        "GET with uppercase path param must find the payload"
+    );
+    let gv: Value = serde_json::from_str(&gb).unwrap();
+    assert_eq!(gv["iv"], "iv-path");
+    assert_eq!(gv["payload"], "payload-path");
+}
+
+/// Full round-trip: POST with uppercase id, PUT response via uppercase path,
+/// GET response via lowercase path — all resolve to the same key.
+#[test]
+fn test_case_insensitive_full_round_trip() {
+    let base_url = get_base_url();
+    let id_lower = fresh_id();
+    let id_upper = id_lower.to_uppercase();
+
+    // Create request with uppercase id.
+    let req_body = json!({"request_id": id_upper, "iv": "rt-iv", "payload": "rt-payload"});
+    let (s, _) = http_post(&format!("{base_url}/request"), &req_body);
+    assert_eq!(s, 200);
+
+    // Consume the request (GET) with mixed path — verifies normalization at GET.
+    let (gs, _) = http_get(&format!("{base_url}/request/{id_upper}"));
+    assert_eq!(gs, 200);
+
+    // PUT response using uppercase path param.
+    let res_body = json!({"iv": "rt-resp-iv", "payload": "rt-resp-payload"});
+    let (ps, _) = http_put(&format!("{base_url}/response/{id_upper}"), &res_body);
+    assert_eq!(ps, 201, "PUT /response with uppercase id must succeed");
+
+    // GET response using lowercase path param.
+    let (rgs, rgb) = http_get(&format!("{base_url}/response/{id_lower}"));
+    assert_eq!(
+        rgs, 200,
+        "GET /response with lowercase id must find the response"
+    );
+    let rv: Value = serde_json::from_str(&rgb).unwrap();
+    assert_eq!(rv["status"], "completed");
+    assert_eq!(rv["response"]["iv"], "rt-resp-iv");
+}
+
 /// Test OpenAPI documentation endpoint exists
 #[test]
 fn test_openapi_endpoint() {


### PR DESCRIPTION
- added .to_lowercase() normalization at all request_id ingestion points (POST body and path params)
- added integration tests verifying uppercase ids normalize to the same Redis key
- fixes [inc-82](https://tfh.enterprise.slack.com/archives/C0B25BNNAB0)