### PR TITLE
feat: server-driven per-app URL overrides on POST /request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,9 @@ jobs:
 
     env:
       REDIS_URL: redis://localhost:6379
+      # Fixture consumed by the app-override integration tests. Must match the
+      # FIXTURE_* constants in tests/integration_test.rs.
+      APP_URL_OVERRIDES: '{"app_integration_override_fixture":{"app_clip_bundle_id":"org.example.integration.Clip","verify_url":"https://world.org/verify"}}'
 
     steps:
       - name: Checkout code

--- a/README.md
+++ b/README.md
@@ -87,8 +87,12 @@ A `docker-compose.test.yml` file provides Redis for integration testing, and com
 # Terminal 1: Start Redis
 docker-compose -f docker-compose.test.yml up -d
 
-# Terminal 2: Start the application
-REDIS_URL=redis://localhost:6379 cargo run
+# Terminal 2: Start the application.
+# APP_URL_OVERRIDES is the fixture the app-override tests assert against; it
+# must match the FIXTURE_* constants in tests/integration_test.rs.
+REDIS_URL=redis://localhost:6379 \
+APP_URL_OVERRIDES='{"app_integration_override_fixture":{"app_clip_bundle_id":"org.example.integration.Clip","verify_url":"https://world.org/verify"}}' \
+cargo run
 
 # Terminal 3: Run the tests
 cargo test --test integration_test
@@ -104,6 +108,7 @@ The integration tests cover:
 - Standalone response flow (World App initiated)
 - Pending status handling
 - Error cases (404s, validation)
+- Per-app URL overrides (mapped/unmapped/absent/malformed `app_id`)
 - OpenAPI documentation endpoint
 
 ### Manual Integration Testing
@@ -159,3 +164,4 @@ Other useful environment variables:
 - `PORT`: Application port (default: 8000)
 - `ENVIRONMENT`: Environment name (development/production)
 - `RUST_LOG`: Logging level (info/debug/trace)
+- `APP_URL_OVERRIDES`: JSON object mapping `app_id → {app_clip_bundle_id?, verify_url?}`. The bridge returns this whole map verbatim in every `POST /request` response (as `app_overrides`) — it takes no `app_id` input and does not inspect which app a request belongs to. The iOS SDK selects its own `app_id` entry client-side to override its built-in App Clip bundle id (the `p` of an `appclip.apple.com/id` default link) and verify base URL. Unset or empty disables the feature (the field is omitted; the SDK keeps its defaults) — this is the kill switch. Malformed JSON is a fatal startup error.

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,10 +3,13 @@
 use dotenvy::dotenv;
 use redis::aio::ConnectionManager;
 use std::env;
+use std::sync::Arc;
 
 mod routes;
 mod server;
 mod utils;
+
+use utils::AppOverrides;
 
 #[tokio::main]
 async fn main() {
@@ -51,7 +54,35 @@ async fn main() {
 
     tracing::info!("✅ Connection to Redis established.");
 
-    server::start(redis).await;
+    let app_overrides = Arc::new(load_app_overrides());
+
+    server::start(redis, app_overrides).await;
+}
+
+/// Load the per-`app_id` URL override map from the `APP_URL_OVERRIDES` env var.
+///
+/// The value is a JSON object of `app_id → {app_clip_url?, verify_url?}`.
+/// Unset or empty ⇒ the feature is off (empty map; the SDK keeps its built-in
+/// defaults). This is the kill switch: clear the env var and restart.
+///
+/// Malformed JSON is a fatal startup error (panic) rather than a silently
+/// empty map — a broken config must fail loudly at deploy time, not degrade
+/// into "no overrides" that looks healthy. Parsed exactly once here; the
+/// resulting map is shared read-only across all requests.
+fn load_app_overrides() -> AppOverrides {
+    let raw = match env::var("APP_URL_OVERRIDES") {
+        Ok(s) if !s.trim().is_empty() => s,
+        _ => {
+            tracing::info!("APP_URL_OVERRIDES not set — app URL overrides disabled.");
+            return AppOverrides::default();
+        }
+    };
+
+    let overrides: AppOverrides = serde_json::from_str(&raw)
+        .expect("APP_URL_OVERRIDES is set but is not valid JSON for app_id → override map");
+
+    tracing::info!("Loaded {} app URL override(s).", overrides.len());
+    overrides
 }
 
 async fn build_redis_pool(redis_url: String) -> redis::RedisResult<ConnectionManager> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,7 +61,7 @@ async fn main() {
 
 /// Load the per-`app_id` URL override map from the `APP_URL_OVERRIDES` env var.
 ///
-/// The value is a JSON object of `app_id → {app_clip_url?, verify_url?}`.
+/// The value is a JSON object of `app_id → {app_clip_bundle_id?, verify_url?}`.
 /// Unset or empty ⇒ the feature is off (empty map; the SDK keeps its built-in
 /// defaults). This is the kill switch: clear the env var and restart.
 ///

--- a/src/routes/request.rs
+++ b/src/routes/request.rs
@@ -12,12 +12,13 @@ use redis::{aio::ConnectionManager, AsyncCommands, ExistenceCheck, SetExpiry, Se
 use schemars::JsonSchema;
 use std::env;
 use std::str::FromStr;
+use std::sync::Arc;
 use tower_http::cors::{AllowHeaders, Any, CorsLayer};
 use uuid::Uuid;
 
 use crate::utils::{
-    handle_redis_error, validate_request_id, RequestPayload, RequestStatus, EXPIRE_AFTER_SECONDS,
-    REQ_STATUS_PREFIX,
+    handle_redis_error, validate_request_id, AppOverrides, RequestPayload, RequestStatus,
+    EXPIRE_AFTER_SECONDS, REQ_STATUS_PREFIX,
 };
 
 const REQ_PREFIX: &str = "req:";
@@ -52,6 +53,10 @@ struct RequestCreatedPayload {
     /// The unique identifier for the request — the client-supplied value if
     /// one was provided, otherwise a server-generated UUID v4.
     request_id: String,
+    /// Temporary workaround for the World ID app rollout.
+    /// to configure deeplink values from the server and set app-specific overrides
+    #[serde(skip_serializing_if = "AppOverrides::is_empty")]
+    app_overrides: AppOverrides,
 }
 
 pub fn handler() -> ApiRouter {
@@ -152,6 +157,7 @@ async fn get_request(
 /// with NX semantics; otherwise generates a UUID v4.
 async fn insert_request(
     Extension(mut redis): Extension<ConnectionManager>,
+    Extension(app_overrides): Extension<Arc<AppOverrides>>,
     Json(body): Json<CreateRequestBody>,
 ) -> Result<Json<RequestCreatedPayload>, StatusCode> {
     let request_id = match body.request_id {
@@ -199,7 +205,10 @@ async fn insert_request(
 
     tracing::info!("Successfully processed /request: {request_id}");
 
-    Ok(Json(RequestCreatedPayload { request_id }))
+    Ok(Json(RequestCreatedPayload {
+        request_id,
+        app_overrides: (*app_overrides).clone(),
+    }))
 }
 
 /// Create a new request by ID idempotently — retries succeed, even if the request exists.

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,4 +1,4 @@
-use std::{env, net::SocketAddr};
+use std::{env, net::SocketAddr, sync::Arc};
 
 use aide::openapi::{Info, License, OpenApi};
 use axum::{extract::DefaultBodyLimit, Extension};
@@ -6,8 +6,9 @@ use redis::aio::ConnectionManager;
 use tokio::{net::TcpListener, signal};
 
 use crate::routes;
+use crate::utils::AppOverrides;
 
-pub async fn start(redis: ConnectionManager) {
+pub async fn start(redis: ConnectionManager, app_overrides: Arc<AppOverrides>) {
     let mut openapi = OpenApi {
         info: Info {
             title: "Wallet Bridge".to_string(),
@@ -27,6 +28,7 @@ pub async fn start(redis: ConnectionManager) {
     let app = routes::handler()
         .finish_api(&mut openapi)
         .layer(Extension(redis))
+        .layer(Extension(app_overrides))
         .layer(Extension(openapi))
         .layer(DefaultBodyLimit::max(5 * 1024 * 1024));
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -30,6 +30,10 @@ pub const REQUEST_ID_MIN_LEN: usize = 16;
 /// - `verify_url` is a *base* URL; the SDK appends its own per-request query
 ///   params (`t/i/k/b`).
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+// Reject unknown keys so a misspelled override field (e.g. the old
+// `app_clip_url`) fails to parse and trips the startup fail-fast, rather than
+// silently producing an empty override that looks healthy but does nothing.
+#[serde(deny_unknown_fields)]
 pub struct AppOverride {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub app_clip_bundle_id: Option<String>,
@@ -152,6 +156,16 @@ mod tests {
             verify_url: None,
         };
         assert_eq!(serde_json::to_string(&empty).unwrap(), "{}");
+    }
+
+    #[test]
+    fn app_overrides_rejects_unknown_fields() {
+        // A misspelled/unknown override key (e.g. the old name `app_clip_url`)
+        // must fail to parse rather than silently producing an empty override
+        // entry — so a bad rollout config fails fast at startup instead of
+        // looking healthy while doing nothing.
+        let raw = r#"{"app_one": {"app_clip_url": "org.one.Clip"}}"#;
+        assert!(serde_json::from_str::<AppOverrides>(raw).is_err());
     }
 
     #[test]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,8 +1,9 @@
-use std::{fmt::Display, str::FromStr};
+use std::{collections::HashMap, fmt::Display, str::FromStr};
 
 use axum::http::StatusCode;
 use redis::RedisError;
 use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
 
 pub const EXPIRE_AFTER_SECONDS: u64 = 900; // Increasing to allow partner verifications.
 pub const REQ_STATUS_PREFIX: &str = "req:status:";
@@ -21,7 +22,25 @@ pub const REQUEST_ID_MAX_LEN: usize = 256;
 /// for picking high-entropy identifiers.
 pub const REQUEST_ID_MIN_LEN: usize = 16;
 
-#[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize, JsonSchema)]
+/// A per-`app_id` override, this is a temporary workaround that enables smooth rollout of our new World ID app.
+///
+/// - `app_clip_bundle_id` is the App Clip's bundle identifier (the `p`
+///   parameter of an `appclip.apple.com/id` default link, e.g.
+///   `org.worldcoin.insight.Clip`).
+/// - `verify_url` is a *base* URL; the SDK appends its own per-request query
+///   params (`t/i/k/b`).
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+pub struct AppOverride {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub app_clip_bundle_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub verify_url: Option<String>,
+}
+
+/// A map with app overrides, loaded from environment during startup
+pub type AppOverrides = HashMap<String, AppOverride>;
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 pub enum RequestStatus {
     /// The request has been initiated by the client
@@ -55,7 +74,7 @@ impl FromStr for RequestStatus {
     }
 }
 
-#[derive(Debug, serde::Deserialize, serde::Serialize, JsonSchema)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
 pub struct RequestPayload {
     /// The initialization vector for the encrypted payload
     iv: String,
@@ -95,4 +114,49 @@ pub fn validate_request_id(id: &str) -> Result<(), StatusCode> {
         return Err(StatusCode::BAD_REQUEST);
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn app_overrides_parse_from_json() {
+        let raw = r#"{
+            "app_one": {"app_clip_bundle_id": "org.one.Clip", "verify_url": "https://world.org/verify"},
+            "app_two": {"app_clip_bundle_id": "org.two.Clip"},
+            "app_three": {"verify_url": "https://world.org/verify"}
+        }"#;
+        let map: AppOverrides = serde_json::from_str(raw).expect("valid override JSON");
+
+        assert_eq!(map.len(), 3);
+        assert_eq!(
+            map["app_one"].verify_url.as_deref(),
+            Some("https://world.org/verify")
+        );
+        assert_eq!(
+            map["app_one"].app_clip_bundle_id.as_deref(),
+            Some("org.one.Clip")
+        );
+        // Independently optional fields.
+        assert!(map["app_two"].verify_url.is_none());
+        assert!(map["app_three"].app_clip_bundle_id.is_none());
+    }
+
+    #[test]
+    fn app_override_omits_absent_fields_when_serialized() {
+        // `skip_serializing_if` keeps the POST /request response lean and lets
+        // the SDK treat "absent" as "fall back to default".
+        let empty = AppOverride {
+            app_clip_bundle_id: None,
+            verify_url: None,
+        };
+        assert_eq!(serde_json::to_string(&empty).unwrap(), "{}");
+    }
+
+    #[test]
+    fn empty_json_object_is_valid_and_disables_feature() {
+        let map: AppOverrides = serde_json::from_str("{}").expect("empty object is valid");
+        assert!(map.is_empty());
+    }
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -402,6 +402,66 @@ fn test_create_request_with_duplicate_id_returns_409() {
     assert_eq!(s2, 409, "second POST with same request_id must 409");
 }
 
+// ---------------------------------------------------------------------------
+// Server-driven URL overrides. The bridge takes no `app_id` input — it returns
+// the whole `app_overrides` map blindly and the SDK picks its own entry.
+//
+// These tests require the bridge to be started with this exact fixture in the
+// `APP_URL_OVERRIDES` env var (CI and the README do this):
+//
+//   {"app_integration_override_fixture":
+//      {"app_clip_bundle_id":"org.example.integration.Clip",
+//       "verify_url":"https://world.org/verify"}}
+// ---------------------------------------------------------------------------
+
+const FIXTURE_APP_ID: &str = "app_integration_override_fixture";
+const FIXTURE_APP_CLIP_BUNDLE_ID: &str = "org.example.integration.Clip";
+const FIXTURE_VERIFY_URL: &str = "https://world.org/verify";
+
+#[test]
+fn test_response_includes_full_override_map() {
+    let base_url = get_base_url();
+    let body = json!({"iv": "x", "payload": "y"});
+
+    let (s, b) = http_post(&format!("{base_url}/request"), &body);
+    assert_eq!(s, 200, "POST /request should succeed: {b}");
+
+    let v: Value = serde_json::from_str(&b).unwrap();
+    let entry = v
+        .get("app_overrides")
+        .and_then(|m| m.get(FIXTURE_APP_ID))
+        .unwrap_or_else(|| panic!("app_overrides map must contain the fixture entry. Is APP_URL_OVERRIDES set to the test fixture? Got: {b}"));
+
+    assert_eq!(
+        entry.get("app_clip_bundle_id").and_then(Value::as_str),
+        Some(FIXTURE_APP_CLIP_BUNDLE_ID),
+        "fixture entry must carry the configured app_clip_bundle_id: {b}"
+    );
+    assert_eq!(
+        entry.get("verify_url").and_then(Value::as_str),
+        Some(FIXTURE_VERIFY_URL),
+        "fixture entry must carry the configured verify_url: {b}"
+    );
+}
+
+#[test]
+fn test_request_id_still_present_alongside_overrides() {
+    // The override map is additive — the core request_id contract is unchanged,
+    // so an SDK that ignores app_overrides still works exactly as before.
+    let base_url = get_base_url();
+    let body = json!({"iv": "x", "payload": "y"});
+
+    let (s, b) = http_post(&format!("{base_url}/request"), &body);
+    assert_eq!(s, 200, "POST /request should succeed: {b}");
+
+    let v: Value = serde_json::from_str(&b).unwrap();
+    let request_id = v.get("request_id").and_then(Value::as_str);
+    assert!(
+        request_id.is_some() && !request_id.unwrap().is_empty(),
+        "request_id must still be present and non-empty: {b}"
+    );
+}
+
 #[test]
 fn test_create_request_without_id_still_generates_uuid() {
     let base_url = get_base_url();


### PR DESCRIPTION
This PR adds app overrides to the response of `POST /request`. This is a temporary workaround that will enable a smooth rollout for RPs to our new World ID app. 