### PR TITLE
Log response endpoint 400 reasons

### DIFF
--- a/src/routes/response.rs
+++ b/src/routes/response.rs
@@ -58,6 +58,13 @@ async fn get_response(
 ) -> Result<Json<Response>, StatusCode> {
     let request_id = request_id.to_lowercase();
     if validate_request_id(&request_id).is_err() {
+        tracing::warn!(
+            method = "GET",
+            request_id = %request_id,
+            status_code = 400,
+            reason = "invalid_request_id",
+            "Rejecting response request"
+        );
         return Err(StatusCode::BAD_REQUEST);
     }
 
@@ -127,6 +134,13 @@ async fn has_response_status(
 ) -> StatusCode {
     let request_id = request_id.to_lowercase();
     if validate_request_id(&request_id).is_err() {
+        tracing::warn!(
+            method = "HEAD",
+            request_id = %request_id,
+            status_code = 400,
+            reason = "invalid_request_id",
+            "Rejecting response request"
+        );
         return StatusCode::BAD_REQUEST;
     }
 
@@ -150,18 +164,46 @@ async fn insert_response(
     Json(request): Json<RequestPayload>,
 ) -> Result<StatusCode, StatusCode> {
     let request_id = request_id.to_lowercase();
-    validate_request_id(&request_id)?;
+    if validate_request_id(&request_id).is_err() {
+        tracing::warn!(
+            method = "PUT",
+            request_id = %request_id,
+            status_code = 400,
+            reason = "invalid_request_id",
+            "Rejecting response request"
+        );
+        return Err(StatusCode::BAD_REQUEST);
+    }
 
     //ANCHOR - Check the request is valid
     let current_status = redis
         .get::<_, Option<String>>(format!("{REQ_STATUS_PREFIX}{request_id}"))
         .await
-        .map_err(handle_redis_error)?
-        .and_then(|s| RequestStatus::from_str(&s).ok());
+        .map_err(handle_redis_error)?;
 
     let Some(current_status) = current_status else {
+        tracing::warn!(
+            method = "PUT",
+            request_id = %request_id,
+            status_code = 400,
+            reason = "request_status_not_found",
+            "Rejecting response request"
+        );
         return Err(StatusCode::BAD_REQUEST);
     };
+
+    let current_status = RequestStatus::from_str(&current_status).map_err(|error| {
+        tracing::warn!(
+            method = "PUT",
+            request_id = %request_id,
+            status_code = 400,
+            reason = "invalid_request_status",
+            stored_status = %current_status,
+            error = %error,
+            "Rejecting response request"
+        );
+        StatusCode::BAD_REQUEST
+    })?;
 
     //ANCHOR - Atomically store the response with TTL if not already set (idempotent)
     let options = SetOptions::default()


### PR DESCRIPTION
## What changed

- add structured warning logs for deliberate `400 Bad Request` responses from `GET`, `HEAD`, and `PUT /response/{request_id}`
- record the HTTP method, request ID, status code, and a stable reason value
- distinguish missing Redis request status from an invalid stored status, including parsing context for the latter

## Why

These handlers returned empty 400 responses without emitting an application log, so Datadog could not identify why a request was rejected. The new fields make these failures searchable and diagnosable while preserving the existing HTTP behavior.

## Impact

No response contracts or status codes change. Deployments collecting the service's JSON stdout logs can query `reason` values including `invalid_request_id`, `request_status_not_found`, and `invalid_request_status`.

## Validation

- `cargo fmt --check` passed
- 4 unit tests passed
- the integration test binary compiled; its 26 tests require the service to be running on `localhost:8000` and failed because no server was running