### PR TITLE
feat: update documentation & start rename to message-bridge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,9 +123,6 @@ jobs:
 
     env:
       REDIS_URL: redis://localhost:6379
-      # Fixture consumed by the app-override integration tests. Must match the
-      # FIXTURE_* constants in tests/integration_test.rs.
-      APP_URL_OVERRIDES: '{"app_integration_override_fixture":{"app_clip_bundle_id":"org.example.integration.Clip","verify_url":"https://world.org/verify"}}'
 
     steps:
       - name: Checkout code
@@ -136,7 +133,4 @@ jobs:
           toolchain: stable
 
       - name: Run integration tests
-        run: |
-          cargo run > bridge.log 2>&1 &
-          until curl -sf http://localhost:8000/ > /dev/null 2>&1; do sleep 1; done
-          cargo test --test integration_test
+        run: cargo test --test integration_test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,11 @@ on:
     branches: [main]
   pull_request:
 
+# Unless we are on the main branch, the workflow should stop and yield to a new run if new code is pushed.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.sha || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'main')}}
+
 env:
   CARGO_TERM_COLOR: always
 
@@ -133,4 +138,4 @@ jobs:
           toolchain: stable
 
       - name: Run integration tests
-        run: cargo test --test integration_test
+        run: cargo test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 # Unless we are on the main branch, the workflow should stop and yield to a new run if new code is pushed.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.sha || github.ref }}
-  cancel-in-progress: ${{ github.ref != 'main')}}
+  cancel-in-progress: ${{ github.ref != 'main' }}
 
 env:
   CARGO_TERM_COLOR: always

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,2 +1,23 @@
-- Start with context in the `README.md`.
-- For any change, ensure it is compliant with all the project definitions in the `README.md`. A particular pitfall is trying to incorporate logic that is client-specific or environment-specific. All functionality should be agnostic to clients and environments.
+# Agent guide
+
+Read `README.md` first. It defines the bridge; every change must preserve these invariants:
+
+- **Opaque payloads.** The bridge only ever handles client-encrypted ciphertext (`iv` + `payload`). Never inspect, transform, or log payload contents.
+- **Single-use.** Requests and responses are read with `GETDEL` — one retrieval, then gone.
+- **No persistence.** Everything lives in Redis with a uniform TTL (`EXPIRE_AFTER_SECONDS` in `src/utils.rs`) and is auto-purged. Don't add durable storage or per-key lifetimes.
+
+The bridge is a dumb relay. **New** functionality must stay agnostic to clients and environments — no client/app-specific branching, no environment-specific behavior. Two intentional, temporary exceptions already exist; don't extend them or add new ones like them:
+
+- `app_overrides` — a per-`app_id` rollout workaround for the World ID app (`src/routes/request.rs`, `src/main.rs`).
+- `PUT /request/:id` — enabled only when `ENVIRONMENT == "staging"` (`src/routes/request.rs`).
+
+## Build, test, lint
+
+Reproduce CI locally before pushing:
+
+```bash
+cargo fmt -- --check
+cargo clippy --all-features          # warnings denied via crate-level attributes
+cargo build --locked
+cargo test                           # in-process; needs only Redis — see README "Testing"
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,2 @@
+- Start with context in the `README.md`.
+- For any change, ensure it is compliant with all the project definitions in the `README.md`. A particular pitfall is trying to incorporate logic that is client-specific or environment-specific. All functionality should be agnostic to clients and environments.

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @m1guelpf @andy-t-wang @decentralgabe @paolodamico
+* @m1guelpf @Takaros999 @paolodamico @kilianglas

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -286,36 +286,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
-name = "curl"
-version = "0.4.49"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79fc3b6dd0b87ba36e565715bf9a2ced221311db47bd18011676f24a6066edbc"
-dependencies = [
- "curl-sys",
- "libc",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "socket2",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "curl-sys"
-version = "0.4.85+curl-8.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0efa6142b5ecc05f6d3eaa39e6af4888b9d3939273fb592c92b7088a8cf3fdb"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "openssl-sys",
- "pkg-config",
- "vcpkg",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -580,12 +550,12 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
 dependencies = [
  "bytes",
- "futures-util",
+ "futures-core",
  "http",
  "http-body",
  "pin-project-lite",
@@ -853,18 +823,6 @@ name = "libc"
 version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
-
-[[package]]
-name = "libz-sys"
-version = "1.1.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15d118bbf3771060e7311cc7bb0545b01d08a8b4a7de949198dec1fa0ca1c0f7"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "linux-raw-sys"
@@ -1635,28 +1593,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-stream"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
-dependencies = [
- "futures-core",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
-name = "tokio-test"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f6d24790a10a7af737693a3e8f1d03faef7e6ca0cc99aae5066f533766de545"
-dependencies = [
- "futures-core",
- "tokio",
- "tokio-stream",
-]
-
-[[package]]
 name = "tokio-util"
 version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2025,15 +1961,14 @@ dependencies = [
  "axum",
  "axum-jsonschema",
  "chrono",
- "curl",
  "dotenvy",
+ "http-body-util",
  "openssl",
  "redis",
  "schemars",
  "serde",
  "serde_json",
  "tokio",
- "tokio-test",
  "tower",
  "tower-http",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -371,36 +371,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
-name = "curl"
-version = "0.4.49"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79fc3b6dd0b87ba36e565715bf9a2ced221311db47bd18011676f24a6066edbc"
-dependencies = [
- "curl-sys",
- "libc",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "socket2",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "curl-sys"
-version = "0.4.85+curl-8.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0efa6142b5ecc05f6d3eaa39e6af4888b9d3939273fb592c92b7088a8cf3fdb"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "openssl-sys",
- "pkg-config",
- "vcpkg",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "darling"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -737,12 +707,12 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
 dependencies = [
  "bytes",
- "futures-util",
+ "futures-core",
  "http",
  "http-body",
  "pin-project-lite",
@@ -1056,18 +1026,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "libz-sys"
-version = "1.1.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15d118bbf3771060e7311cc7bb0545b01d08a8b4a7de949198dec1fa0ca1c0f7"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
 ]
 
 [[package]]
@@ -2206,17 +2164,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-test"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f6d24790a10a7af737693a3e8f1d03faef7e6ca0cc99aae5066f533766de545"
-dependencies = [
- "futures-core",
- "tokio",
- "tokio-stream",
-]
-
-[[package]]
 name = "tokio-util"
 version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2773,8 +2720,8 @@ dependencies = [
  "axum",
  "axum-jsonschema",
  "chrono",
- "curl",
  "dotenvy",
+ "http-body-util",
  "openssl",
  "redis",
  "schemars",
@@ -2782,7 +2729,6 @@ dependencies = [
  "serde_json",
  "telemetry-batteries",
  "tokio",
- "tokio-test",
  "tower",
  "tower-http",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,9 +3,10 @@ license = "MIT"
 edition = "2021"
 version = "0.1.0"
 name = "world-id-bridge"
+publish = "false"
 authors = ["Miguel Piedrafita <rust@miguel.build>"]
 repository = "https://github.com/worldcoin/wallet-bridge"
-description = "A bridge between the World ID SDK and the World App"
+description = "A dumb, environment and client agnostic relay of arbitrary messages. It lets two parties share an arbitrary message where parties can gossip a symmetric key off-band"
 
 [dependencies]
 aide = { version = "0.13.2", features = ["axum", "scalar"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ license = "MIT"
 edition = "2021"
 version = "0.1.0"
 name = "world-id-bridge"
-publish = "false"
+publish = false
 authors = ["Miguel Piedrafita <rust@miguel.build>"]
 repository = "https://github.com/worldcoin/wallet-bridge"
 description = "A dumb, environment and client agnostic relay of arbitrary messages. It lets two parties share an arbitrary message where parties can gossip a symmetric key off-band"
@@ -19,7 +19,6 @@ schemars = { version = "0.8.16", features = ["uuid1"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.145"
 tokio = { version = "1.48.0", features = ["full"] }
-tower = "0.5.1"
 tower-http = { version = "0.6.6", features = ["cors"] }
 tracing = { version = "0.1", features = ["log"] }
 tracing-subscriber = { version = "0.3.20", default-features = false, features = ["fmt", "json"] }
@@ -29,5 +28,5 @@ uuid = { version = "1.18.1", features = ["v4", "serde"] }
 chrono = "0.4.26"
 
 [dev-dependencies]
-curl = "0.4"
-tokio-test = "0.4"
+http-body-util = "0.1.3"
+tower = { version = "0.5.2", features = ["util"] }

--- a/README.md
+++ b/README.md
@@ -25,8 +25,6 @@ IDKit ->> Bridge: Poll for updates GET /response/:id
 Bridge ->> IDKit: <response>
 ```
 
-### Endpoints
-
 - `POST /request`: Called by IDKit. Initializes a proof verification request.
 - `GET /request/:id`: Called by Authenticator. Used to fetch the proof verification request. One time use.
 - `PUT /response/:id`: Called by Authenticator. Used to send the proof back to the application.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ symmetric key off-band.
 
 The bridge is made so that it cannot eavesdrop on any messages. The bridge expects only ciphertext. **All clients MUST encrypt all payloads before submitting to the bridge.**.
 
-**Importantly** this bridge is completely agnostic to any client or environment, it simply relays messages, hence it implements no logic or opinions related to client handling.
+- **Importantly** this bridge is completely agnostic to any client or environment, it simply relays messages, hence it implements no logic or opinions related to client handling.
+- All messages received by this bridge are temporarily held for delivery, but are automatically purged after a period of time. This service has and SHOULD NOT have _persisting_ storage.
 
 ## Use Case: World ID Protocol
 
@@ -29,31 +30,22 @@ Bridge ->> IDKit: <response>
 - `GET /request/:id`: Called by Authenticator. Used to fetch the proof verification request. One time use.
 - `PUT /response/:id`: Called by Authenticator. Used to send the proof back to the application.
 - `GET /response/:id`: Called by IDKit. Continuous pulling to fetch the status of the request and the response if available. Response can only be retrieved once.
-- `POST /response`: Called by Authenticator. Creates a standalone response without a prior request.
 
-### Standalone Response Flow (Authenticator Initiates)
+### Standalone Response Flow
 
-Authenticator App initiates without a prior IDKit request:
+This flow allows a client to send a `/response` without first generating a `/request` first.
 
 ```mermaid
 sequenceDiagram
-    participant Authenticator
+    participant ClientA
     participant Bridge
-    participant IDKit
+    participant ClientB
 
-    Authenticator->>Bridge: POST /response (payload)
-    Bridge->>Authenticator: 201 CREATED {request_id}
-    IDKit->>Bridge: GET /response/:request_id
-    Bridge->>IDKit: 200 OK {response}
+    ClientA->>Bridge: POST /response (payload)
+    Bridge->>ClientA: 201 CREATED {request_id}
+    ClientB->>Bridge: GET /response/:request_id
+    Bridge->>ClientB: 200 OK {response}
 ```
-
-**World App workflow:**
-1. POST /response with encrypted payload
-2. Receive generated request_id
-3. Send request_id to IDKit
-4. IDKit retrieves response using GET /response/:request_id
-
-**TTL:** 15 minutes (900 seconds) - responses expire automatically
 
 ## Local Development
 

--- a/README.md
+++ b/README.md
@@ -26,10 +26,16 @@ IDKit ->> Bridge: Poll for updates GET /response/:id
 Bridge ->> IDKit: <response>
 ```
 
+### Endpoints
+
 - `POST /request`: Called by IDKit. Initializes a proof verification request.
 - `GET /request/:id`: Called by Authenticator. Used to fetch the proof verification request. One time use.
+- `HEAD /request/:id`: Existence check for a request. `200` if present, `404` otherwise.
 - `PUT /response/:id`: Called by Authenticator. Used to send the proof back to the application.
 - `GET /response/:id`: Called by IDKit. Continuous pulling to fetch the status of the request and the response if available. Response can only be retrieved once.
+- `HEAD /response/:id`: Existence check for a request's status. `200` if present, `404` otherwise.
+- `POST /response`: Called by a client to create a standalone response without a prior request (see [Standalone Response Flow](#standalone-response-flow)).
+- `PUT /request/:id`: Staging only (`ENVIRONMENT == "staging"`). Idempotent request upsert.
 
 ### Standalone Response Flow
 
@@ -59,9 +65,9 @@ When building the Dockerfile locally remember to specify the `--platform=linux/a
 
 ## Testing
 
-Integration tests use Redis (dockerized in `docker-compose.test.yml`), which can be run with:
+Integration tests build the bridge in-process and drive it directly, so the only external dependency is Redis (override its location with `REDIS_URL`):
 
 ```bash
-docker-compose -f docker-compose.test.yml up
+docker-compose -f docker-compose.test.yml up -d
 cargo test
 ```

--- a/README.md
+++ b/README.md
@@ -1,12 +1,17 @@
-# Wallet Bridge
+# Message Bridge (previously Wallet Bridge)
 
-> **Warning** This project is still in early alpha.
+The message bridge is a **dumb**, environment and client agnostic relay of arbitrary messages. It lets two parties share an arbitrary message where parties can gossip a 
+symmetric key off-band.
 
-An end-to-end encrypted bridge between the World ID SDK and World App. This bridge is used to pass zero-knowledge proofs for World ID verifications.
+The bridge is made so that it cannot eavesdrop on any messages. The bridge expects only ciphertext. **All clients MUST encrypt all payloads before submitting to the bridge.**.
 
-More details in the [docs](https://docs.world.org/world-id/further-reading/protocol-internals).
+**Importantly** this bridge is completely agnostic to any client or environment, it simply relays messages, hence it implements no logic or opinions related to client handling.
 
-## Flow
+## Use Case: World ID Protocol
+
+The bridge is currently used in the [World ID Protocol](https://github.com/worldcoin/world-id-protocol). The most used path is for RPs to request proofs from users (to their Authenticators) and for Authenticators to send back proofs.
+
+### Example Flow
 
 ```mermaid
 sequenceDiagram
@@ -20,20 +25,7 @@ IDKit ->> Bridge: Poll for updates GET /response/:id
 Bridge ->> IDKit: <response>
 ```
 
-```mermaid
-flowchart
-A[IDKit posts request /request] --> B[Request is stored in the bridge with status = initialized]
-B --> C[IDKit starts polling /response/:id]
-C --> D[User scans QR code with requestId & decryption key]
-D --> E[App fetches request at /request/:id]
-E --> F[Bridge updates status = retrieved]
-F -- Status updated = retrieved --> C
-F --> G[App generates proof and PUTs to /response/:id]
-G --> H[Bridge stores response. One-time retrieval]
-H -- Response provided --> C
-```
-
-## Endpoints
+### Endpoints
 
 - `POST /request`: Called by IDKit. Initializes a proof verification request.
 - `GET /request/:id`: Called by Authenticator. Used to fetch the proof verification request. One time use.
@@ -77,91 +69,9 @@ When building the Dockerfile locally remember to specify the `--platform=linux/a
 
 ## Testing
 
-### Integration Testing
-
-A `docker-compose.test.yml` file provides Redis for integration testing, and comprehensive integration tests are available in the `tests/` directory.
-
-#### Running Integration Tests
+Integration tests use Redis (dockerized in `docker-compose.test.yml`), which can be run with:
 
 ```bash
-# Terminal 1: Start Redis
-docker-compose -f docker-compose.test.yml up -d
-
-# Terminal 2: Start the application.
-# APP_URL_OVERRIDES is the fixture the app-override tests assert against; it
-# must match the FIXTURE_* constants in tests/integration_test.rs.
-REDIS_URL=redis://localhost:6379 \
-APP_URL_OVERRIDES='{"app_integration_override_fixture":{"app_clip_bundle_id":"org.example.integration.Clip","verify_url":"https://world.org/verify"}}' \
-cargo run
-
-# Terminal 3: Run the tests
-cargo test --test integration_test
+docker-compose -f docker-compose.test.yml up
+cargo test
 ```
-
-For more details, see [tests/README.md](tests/README.md).
-
-#### What's Tested
-
-The integration tests cover:
-- Request creation and retrieval (one-time use)
-- Response submission and retrieval
-- Standalone response flow (World App initiated)
-- Pending status handling
-- Error cases (404s, validation)
-- Per-app URL overrides (mapped/unmapped/absent/malformed `app_id`)
-- OpenAPI documentation endpoint
-
-### Manual Integration Testing
-
-#### Test Request Flow
-
-```bash
-# Create a request
-REQUEST_ID=$(curl -s -X POST http://localhost:8000/request \
-  -H "Content-Type: application/json" \
-  -d '{"iv":"test_iv","payload":"test_payload"}' | jq -r '.request_id')
-
-# Verify request exists
-curl -I http://localhost:8000/request/$REQUEST_ID
-
-# Retrieve request (one-time use)
-curl http://localhost:8000/request/$REQUEST_ID
-
-# Verify request was deleted (should return 404)
-curl http://localhost:8000/request/$REQUEST_ID
-```
-
-#### Test Response Flow
-
-```bash
-# Create a request
-REQUEST_ID=$(curl -s -X POST http://localhost:8000/request \
-  -H "Content-Type: application/json" \
-  -d '{"iv":"test","payload":"test"}' | jq -r '.request_id')
-
-# Submit a response
-curl -X PUT http://localhost:8000/response/$REQUEST_ID \
-  -H "Content-Type: application/json" \
-  -d '{"iv":"response","payload":"response"}'
-
-# Retrieve the response
-curl http://localhost:8000/response/$REQUEST_ID
-```
-
-#### Test Standalone Response Flow
-
-```bash
-# Create standalone response (Authenticator initiated)
-RESPONSE_ID=$(curl -s -X POST http://localhost:8000/response \
-  -H "Content-Type: application/json" \
-  -d '{"iv":"standalone","payload":"standalone"}' | jq -r '.request_id')
-
-# Retrieve the response
-curl http://localhost:8000/response/$RESPONSE_ID
-```
-
-Other useful environment variables:
-- `PORT`: Application port (default: 8000)
-- `ENVIRONMENT`: Environment name (development/production)
-- `RUST_LOG`: Logging level (info/debug/trace)
-- `APP_URL_OVERRIDES`: JSON object mapping `app_id → {app_clip_bundle_id?, verify_url?}`. The bridge returns this whole map verbatim as `app_overrides`, but **only to clients that opt in** by sending `"supports_app_overrides": true` on `POST /request` — it takes no `app_id` input and does not inspect which app a request belongs to. Clients that don't opt in (everything shipped before the feature, and any strict JSON parser that rejects unknown keys) get the legacy `{request_id}` response, so a server-side rollout can't break them. The iOS SDK selects its own `app_id` entry client-side to override its built-in App Clip bundle id (the `p` of an `appclip.apple.com/id` default link) and verify base URL. Unset or empty disables the feature for everyone (the field is omitted; the SDK keeps its defaults) — this is the kill switch. Malformed JSON is a fatal startup error.

--- a/build.rs
+++ b/build.rs
@@ -24,6 +24,6 @@ fn main() {
     println!("cargo:rustc-env=STATIC_BUILD_DATE={}", get_compile_date());
 
     if let Some(rev) = get_git_rev() {
-        println!("cargo:rustc-env=GIT_REV={}", rev);
+        println!("cargo:rustc-env=GIT_REV={rev}");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,44 @@
+#![deny(clippy::all, clippy::pedantic, clippy::nursery)]
+
+use std::sync::Arc;
+
+use aide::openapi::{Info, License, OpenApi};
+use axum::{extract::DefaultBodyLimit, Extension};
+use redis::aio::ConnectionManager;
+
+use crate::utils::AppOverrides;
+
+pub mod routes;
+pub mod server;
+pub mod utils;
+
+/// Assemble the fully-wired application router.
+///
+/// Shared by the binary (via [`server::start`]) and the integration tests so
+/// both exercise the exact same routes, middleware stack, and `OpenAPI` document.
+/// Tests drive the returned router in-process with `tower::ServiceExt::oneshot`,
+/// so no separately-running bridge is required.
+pub fn app(redis: ConnectionManager, app_overrides: Arc<AppOverrides>) -> axum::Router {
+    let mut openapi = OpenApi {
+        info: Info {
+            title: "Message Bridge".to_string(),
+            summary: Some(
+                "A dumb, environment and client agnostic relay of arbitrary messages. It lets two parties share an arbitrary message where parties can gossip a symmetric key off-band.".to_string(),
+            ),
+            license: Some(License {
+                name: "MIT".to_string(),
+                identifier: Some("MIT".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    routes::handler()
+        .finish_api(&mut openapi)
+        .layer(Extension(redis))
+        .layer(Extension(app_overrides))
+        .layer(Extension(openapi))
+        .layer(DefaultBodyLimit::max(5 * 1024 * 1024))
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,11 +5,7 @@ use redis::aio::ConnectionManager;
 use std::env;
 use std::sync::Arc;
 
-mod routes;
-mod server;
-mod utils;
-
-use utils::AppOverrides;
+use world_id_bridge::utils::AppOverrides;
 
 #[tokio::main]
 async fn main() {
@@ -56,7 +52,7 @@ async fn main() {
 
     let app_overrides = Arc::new(load_app_overrides());
 
-    server::start(redis, app_overrides).await;
+    world_id_bridge::server::start(redis, app_overrides).await;
 }
 
 /// Load the per-`app_id` URL override map from the `APP_URL_OVERRIDES` env var.

--- a/src/routes/response.rs
+++ b/src/routes/response.rs
@@ -197,7 +197,7 @@ async fn insert_response(
     Ok(StatusCode::CREATED)
 }
 
-/// Create a new standalone response (World App initiates)
+/// Create a new standalone response
 async fn create_response(
     Extension(mut redis): Extension<ConnectionManager>,
     Json(request): Json<RequestPayload>,

--- a/src/server.rs
+++ b/src/server.rs
@@ -11,9 +11,9 @@ use crate::utils::AppOverrides;
 pub async fn start(redis: ConnectionManager, app_overrides: Arc<AppOverrides>) {
     let mut openapi = OpenApi {
         info: Info {
-            title: "Wallet Bridge".to_string(),
+            title: "Message Bridge".to_string(),
             summary: Some(
-                "An end-to-end encrypted bridge for communicating with World App.".to_string(),
+                "A dumb, environment and client agnostic relay of arbitrary messages. It lets two parties share an arbitrary message where parties can gossip a symmetric key off-band.".to_string(),
             ),
             license: Some(License {
                 name: "MIT".to_string(),
@@ -40,7 +40,7 @@ pub async fn start(redis: ConnectionManager, app_overrides: Arc<AppOverrides>) {
         .await
         .expect("Failed to bind address");
 
-    println!("🪩 World Bridge started on http://{address}");
+    println!("🔛💬 Message Bridge started on http://{address}");
 
     axum::serve(listener, app.into_make_service())
         .with_graceful_shutdown(shutdown_signal())

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,36 +1,18 @@
 use std::{env, net::SocketAddr, sync::Arc};
 
-use aide::openapi::{Info, License, OpenApi};
-use axum::{extract::DefaultBodyLimit, Extension};
 use redis::aio::ConnectionManager;
 use tokio::{net::TcpListener, signal};
 
-use crate::routes;
 use crate::utils::AppOverrides;
 
+/// Bind the configured address and serve the bridge until a shutdown signal.
+///
+/// # Panics
+///
+/// Panics if `PORT` is set but not parseable as a port, if binding the TCP
+/// listener fails, or if the server exits with an error.
 pub async fn start(redis: ConnectionManager, app_overrides: Arc<AppOverrides>) {
-    let mut openapi = OpenApi {
-        info: Info {
-            title: "Message Bridge".to_string(),
-            summary: Some(
-                "A dumb, environment and client agnostic relay of arbitrary messages. It lets two parties share an arbitrary message where parties can gossip a symmetric key off-band.".to_string(),
-            ),
-            license: Some(License {
-                name: "MIT".to_string(),
-                identifier: Some("MIT".to_string()),
-                ..Default::default()
-            }),
-            ..Default::default()
-        },
-        ..Default::default()
-    };
-
-    let app = routes::handler()
-        .finish_api(&mut openapi)
-        .layer(Extension(redis))
-        .layer(Extension(app_overrides))
-        .layer(Extension(openapi))
-        .layer(DefaultBodyLimit::max(5 * 1024 * 1024));
+    let router = crate::app(redis, app_overrides);
 
     let address = SocketAddr::from((
         [0, 0, 0, 0],
@@ -42,7 +24,7 @@ pub async fn start(redis: ConnectionManager, app_overrides: Arc<AppOverrides>) {
 
     println!("🔛💬 Message Bridge started on http://{address}");
 
-    axum::serve(listener, app.into_make_service())
+    axum::serve(listener, router.into_make_service())
         .with_graceful_shutdown(shutdown_signal())
         .await
         .expect("Failed to start server");

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -49,9 +49,9 @@ pub type AppOverrides = HashMap<String, AppOverride>;
 pub enum RequestStatus {
     /// The request has been initiated by the client
     Initialized,
-    /// The request has been retrieved by World App
+    /// The request has been retrieved
     Retrieved,
-    /// The request has received a response from World App
+    /// The request has received a response
     Completed,
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -8,18 +8,20 @@ use serde::{Deserialize, Serialize};
 pub const EXPIRE_AFTER_SECONDS: u64 = 900; // Increasing to allow partner verifications.
 pub const REQ_STATUS_PREFIX: &str = "req:status:";
 
-/// Maximum length of a `request_id`, whether supplied by the client on
-/// `POST /request` or extracted from a route path. Bounds Redis-key memory and
-/// keeps URLs reasonable; 256 is more than enough for UUIDs (36), HKDF-derived
-/// hex (64), and base64-shaped identifiers.
+/// Maximum length of a `request_id`.
+///
+/// Whether supplied by the client on `POST /request` or extracted from a route
+/// path. Bounds Redis-key memory and keeps URLs reasonable; 256 is more than
+/// enough for UUIDs (36), HKDF-derived hex (64), and base64-shaped identifiers.
 pub const REQUEST_ID_MAX_LEN: usize = 256;
 
-/// Minimum length of a `request_id`. Anything shorter is almost certainly a
-/// mistake — UUIDs are 36 chars, UUID-simple is 32, HKDF-derived hex is 64,
-/// and base64url of 12 random bytes is 16. The bound doesn't enforce
-/// cryptographic entropy on its own (a 16-char string of `aaaa…` passes),
-/// but it stops trivial typos and obvious attacks; the RP is responsible
-/// for picking high-entropy identifiers.
+/// Minimum length of a `request_id`.
+///
+/// Anything shorter is almost certainly a mistake — UUIDs are 36 chars,
+/// UUID-simple is 32, HKDF-derived hex is 64, and base64url of 12 random bytes
+/// is 16. The bound doesn't enforce cryptographic entropy on its own (a 16-char
+/// string of `aaaa…` passes), but it stops trivial typos and obvious attacks;
+/// the RP is responsible for picking high-entropy identifiers.
 pub const REQUEST_ID_MIN_LEN: usize = 16;
 
 /// A per-`app_id` override, this is a temporary workaround that enables smooth rollout of our new World ID app.
@@ -87,6 +89,7 @@ pub struct RequestPayload {
 }
 
 impl RequestPayload {
+    #[must_use]
     pub const fn new(iv: String, payload: String) -> Self {
         Self { iv, payload }
     }
@@ -98,15 +101,21 @@ pub fn handle_redis_error(e: RedisError) -> StatusCode {
     StatusCode::INTERNAL_SERVER_ERROR
 }
 
-/// Validate a `request_id` (path param or client-supplied body field):
-/// length between `REQUEST_ID_MIN_LEN` and `REQUEST_ID_MAX_LEN`, charset
-/// limited to URL-path-safe ASCII (alphanumeric plus `-`, `_`, `.`).
+/// Validate a `request_id` (path param or client-supplied body field).
+///
+/// Length must be between `REQUEST_ID_MIN_LEN` and `REQUEST_ID_MAX_LEN`, and the
+/// charset is limited to URL-path-safe ASCII (alphanumeric plus `-`, `_`, `.`).
 ///
 /// `:` is intentionally excluded from the charset: an ID like `status:foo`
 /// would round-trip into the Redis key `req:status:foo`, colliding with the
 /// status-namespace key `req:status:foo` that the bridge writes for some
 /// other request. Keeping the charset disjoint from the literal `:` prevents
 /// that overlap by construction.
+///
+/// # Errors
+///
+/// Returns [`StatusCode::BAD_REQUEST`] if `id` is outside the length bounds or
+/// contains characters outside the allowed charset.
 pub fn validate_request_id(id: &str) -> Result<(), StatusCode> {
     if id.len() < REQUEST_ID_MIN_LEN || id.len() > REQUEST_ID_MAX_LEN {
         return Err(StatusCode::BAD_REQUEST);

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,0 +1,94 @@
+//! In-process test server for the message bridge.
+//!
+//! Integration tests build the real application router via [`world_id_bridge::app`]
+
+#![allow(dead_code, reason = "used in integration tests")]
+
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{Method, Request};
+use http_body_util::BodyExt;
+use redis::aio::ConnectionManager;
+use serde_json::Value;
+use tower::ServiceExt;
+use world_id_bridge::app;
+use world_id_bridge::utils::{AppOverride, AppOverrides};
+
+/// App-override fixture the override tests assert against. Injected directly
+/// into the router by the harness, so those tests need no `APP_URL_OVERRIDES`
+/// env var.
+pub const FIXTURE_APP_ID: &str = "app_integration_override_fixture";
+pub const FIXTURE_APP_CLIP_BUNDLE_ID: &str = "org.example.integration.Clip";
+pub const FIXTURE_VERIFY_URL: &str = "https://world.org/verify";
+
+fn fixture_overrides() -> AppOverrides {
+    let mut overrides = AppOverrides::new();
+    overrides.insert(
+        FIXTURE_APP_ID.to_string(),
+        AppOverride {
+            app_clip_bundle_id: Some(FIXTURE_APP_CLIP_BUNDLE_ID.to_string()),
+            verify_url: Some(FIXTURE_VERIFY_URL.to_string()),
+        },
+    );
+    overrides
+}
+
+async fn redis_connection() -> ConnectionManager {
+    let url = std::env::var("REDIS_URL").unwrap_or_else(|_| "redis://127.0.0.1:6379".to_string());
+    let client = redis::Client::open(url).expect("REDIS_URL must be a valid Redis URL");
+    ConnectionManager::new(client).await.expect(
+        "integration tests need a running Redis — start one with \
+         `docker-compose -f docker-compose.test.yml up -d` (see README \"Testing\")",
+    )
+}
+
+/// Build the real bridge router, wired to a local Redis and the override fixture.
+pub async fn test_app() -> axum::Router {
+    app(redis_connection().await, Arc::new(fixture_overrides()))
+}
+
+async fn send(
+    app: &axum::Router,
+    method: Method,
+    route: &str,
+    body: Option<&Value>,
+) -> (u16, String) {
+    let builder = Request::builder().uri(route).method(method);
+    let request = match body {
+        Some(json) => builder
+            .header("Content-Type", "application/json")
+            .body(Body::from(json.to_string())),
+        None => builder.body(Body::empty()),
+    }
+    .expect("failed to build request");
+
+    let response = app
+        .clone()
+        .oneshot(request)
+        .await
+        .expect("router service is infallible");
+    let status = response.status().as_u16();
+    let bytes = response
+        .into_body()
+        .collect()
+        .await
+        .expect("failed to read response body")
+        .to_bytes();
+    (
+        status,
+        String::from_utf8(bytes.to_vec()).unwrap_or_default(),
+    )
+}
+
+pub async fn get(app: &axum::Router, route: &str) -> (u16, String) {
+    send(app, Method::GET, route, None).await
+}
+
+pub async fn post(app: &axum::Router, route: &str, body: &Value) -> (u16, String) {
+    send(app, Method::POST, route, Some(body)).await
+}
+
+pub async fn put(app: &axum::Router, route: &str, body: &Value) -> (u16, String) {
+    send(app, Method::PUT, route, Some(body)).await
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,110 +1,13 @@
-use curl::easy::{Easy, List};
 use serde_json::{json, Value};
-use std::env;
-use std::io::Read;
 use uuid::Uuid;
 
-/// Helper to get the base URL for the wallet bridge service
-fn get_base_url() -> String {
-    env::var("WALLET_BRIDGE_URL").unwrap_or_else(|_| "http://localhost:8000".to_string())
-}
-
-/// Helper to perform a GET request and return (status_code, body)
-fn http_get(url: &str) -> (u32, String) {
-    let mut easy = Easy::new();
-    easy.url(url).unwrap();
-
-    let mut response_body = Vec::new();
-    {
-        let mut transfer = easy.transfer();
-        transfer
-            .write_function(|data| {
-                response_body.extend_from_slice(data);
-                Ok(data.len())
-            })
-            .unwrap();
-        transfer.perform().unwrap();
-    }
-
-    let status_code = easy.response_code().unwrap();
-    let body = String::from_utf8(response_body).unwrap_or_default();
-    (status_code, body)
-}
-
-/// Helper to perform a POST request with JSON body and return (status_code, body)
-fn http_post(url: &str, json_body: &Value) -> (u32, String) {
-    let mut easy = Easy::new();
-    easy.url(url).unwrap();
-    easy.post(true).unwrap();
-
-    let json_string = json_body.to_string();
-    let mut json_bytes = json_string.as_bytes();
-    easy.post_field_size(json_bytes.len() as u64).unwrap();
-
-    let mut headers = List::new();
-    headers.append("Content-Type: application/json").unwrap();
-    easy.http_headers(headers).unwrap();
-
-    let mut response_body = Vec::new();
-    {
-        let mut transfer = easy.transfer();
-        transfer
-            .read_function(|buf| Ok(json_bytes.read(buf).unwrap_or(0)))
-            .unwrap();
-        transfer
-            .write_function(|data| {
-                response_body.extend_from_slice(data);
-                Ok(data.len())
-            })
-            .unwrap();
-        transfer.perform().unwrap();
-    }
-
-    let status_code = easy.response_code().unwrap();
-    let body = String::from_utf8(response_body).unwrap_or_default();
-    (status_code, body)
-}
-
-/// Helper to perform a PUT request with JSON body and return (status_code, body)
-fn http_put(url: &str, json_body: &Value) -> (u32, String) {
-    let mut easy = Easy::new();
-    easy.url(url).unwrap();
-    easy.put(true).unwrap();
-
-    let json_string = json_body.to_string();
-    let json_len = json_string.len();
-    let mut json_bytes = json_string.as_bytes();
-    easy.in_filesize(json_len as u64).unwrap();
-
-    let mut headers = List::new();
-    headers.append("Content-Type: application/json").unwrap();
-    easy.http_headers(headers).unwrap();
-
-    let mut response_body = Vec::new();
-    {
-        let mut transfer = easy.transfer();
-        transfer
-            .read_function(|buf| Ok(json_bytes.read(buf).unwrap_or(0)))
-            .unwrap();
-        transfer
-            .write_function(|data| {
-                response_body.extend_from_slice(data);
-                Ok(data.len())
-            })
-            .unwrap();
-        transfer.perform().unwrap();
-    }
-
-    let status_code = easy.response_code().unwrap();
-    let body = String::from_utf8(response_body).unwrap_or_default();
-    (status_code, body)
-}
+mod common;
 
 /// Test the root endpoint returns service information
-#[test]
-fn test_root_endpoint() {
-    let base_url = get_base_url();
-    let (status_code, body) = http_get(&base_url);
+#[tokio::test]
+async fn test_root_endpoint() {
+    let app = common::test_app().await;
+    let (status_code, body) = common::get(&app, "/").await;
 
     assert_eq!(status_code, 200);
 
@@ -114,16 +17,15 @@ fn test_root_endpoint() {
 }
 
 /// Test POST /request creates a new request and returns a request_id
-#[test]
-fn test_create_request() {
-    let base_url = get_base_url();
+#[tokio::test]
+async fn test_create_request() {
+    let app = common::test_app().await;
     let payload = json!({
         "iv": "test_iv",
         "payload": "test_payload"
     });
 
-    let url = format!("{}/request", base_url);
-    let (status_code, body) = http_post(&url, &payload);
+    let (status_code, body) = common::post(&app, "/request", &payload).await;
 
     assert_eq!(status_code, 200);
 
@@ -134,9 +36,9 @@ fn test_create_request() {
 }
 
 /// Test GET /request/:id retrieves the request (one-time use)
-#[test]
-fn test_get_request_one_time_use() {
-    let base_url = get_base_url();
+#[tokio::test]
+async fn test_get_request_one_time_use() {
+    let app = common::test_app().await;
 
     // Create a request
     let payload = json!({
@@ -144,16 +46,15 @@ fn test_get_request_one_time_use() {
         "payload": "get_test_payload"
     });
 
-    let create_url = format!("{}/request", base_url);
-    let (status_code, body) = http_post(&create_url, &payload);
+    let (status_code, body) = common::post(&app, "/request", &payload).await;
     assert_eq!(status_code, 200);
 
     let create_json: Value = serde_json::from_str(&body).expect("Failed to parse JSON");
     let request_id = create_json["request_id"].as_str().unwrap();
 
     // First GET should succeed
-    let get_url = format!("{}/request/{}", base_url, request_id);
-    let (first_status, first_body) = http_get(&get_url);
+    let get_url = format!("/request/{request_id}");
+    let (first_status, first_body) = common::get(&app, &get_url).await;
 
     assert_eq!(first_status, 200);
 
@@ -162,14 +63,14 @@ fn test_get_request_one_time_use() {
     assert_eq!(first_json["payload"], "get_test_payload");
 
     // Second GET should fail (one-time use)
-    let (second_status, _) = http_get(&get_url);
+    let (second_status, _) = common::get(&app, &get_url).await;
     assert_eq!(second_status, 404);
 }
 
 /// Test PUT /response/:id stores a response for a request
-#[test]
-fn test_put_response_for_request() {
-    let base_url = get_base_url();
+#[tokio::test]
+async fn test_put_response_for_request() {
+    let app = common::test_app().await;
 
     // Create a request
     let request_payload = json!({
@@ -177,8 +78,7 @@ fn test_put_response_for_request() {
         "payload": "request_payload"
     });
 
-    let create_url = format!("{}/request", base_url);
-    let (status_code, body) = http_post(&create_url, &request_payload);
+    let (status_code, body) = common::post(&app, "/request", &request_payload).await;
     assert_eq!(status_code, 200);
 
     let create_json: Value = serde_json::from_str(&body).expect("Failed to parse JSON");
@@ -190,16 +90,16 @@ fn test_put_response_for_request() {
         "payload": "response_payload"
     });
 
-    let put_url = format!("{}/response/{}", base_url, request_id);
-    let (put_status, _) = http_put(&put_url, &response_payload);
+    let put_url = format!("/response/{request_id}");
+    let (put_status, _) = common::put(&app, &put_url, &response_payload).await;
 
     assert_eq!(put_status, 201);
 }
 
 /// Test GET /response/:id retrieves the response
-#[test]
-fn test_get_response() {
-    let base_url = get_base_url();
+#[tokio::test]
+async fn test_get_response() {
+    let app = common::test_app().await;
 
     // Create a request
     let request_payload = json!({
@@ -207,8 +107,7 @@ fn test_get_response() {
         "payload": "req_payload"
     });
 
-    let create_url = format!("{}/request", base_url);
-    let (status_code, body) = http_post(&create_url, &request_payload);
+    let (status_code, body) = common::post(&app, "/request", &request_payload).await;
     assert_eq!(status_code, 200);
 
     let create_json: Value = serde_json::from_str(&body).expect("Failed to parse JSON");
@@ -220,13 +119,13 @@ fn test_get_response() {
         "payload": "resp_payload"
     });
 
-    let put_url = format!("{}/response/{}", base_url, request_id);
-    let (put_status, _) = http_put(&put_url, &response_payload);
+    let put_url = format!("/response/{request_id}");
+    let (put_status, _) = common::put(&app, &put_url, &response_payload).await;
     assert_eq!(put_status, 201);
 
     // Get the response
-    let get_url = format!("{}/response/{}", base_url, request_id);
-    let (get_status, get_body) = http_get(&get_url);
+    let get_url = format!("/response/{request_id}");
+    let (get_status, get_body) = common::get(&app, &get_url).await;
 
     assert_eq!(get_status, 200);
 
@@ -237,9 +136,9 @@ fn test_get_response() {
 }
 
 /// Test GET /response/:id returns pending status when response not yet submitted
-#[test]
-fn test_response_pending_status() {
-    let base_url = get_base_url();
+#[tokio::test]
+async fn test_response_pending_status() {
+    let app = common::test_app().await;
 
     // Create a request
     let request_payload = json!({
@@ -247,16 +146,15 @@ fn test_response_pending_status() {
         "payload": "pending_payload"
     });
 
-    let create_url = format!("{}/request", base_url);
-    let (status_code, body) = http_post(&create_url, &request_payload);
+    let (status_code, body) = common::post(&app, "/request", &request_payload).await;
     assert_eq!(status_code, 200);
 
     let create_json: Value = serde_json::from_str(&body).expect("Failed to parse JSON");
     let request_id = create_json["request_id"].as_str().unwrap();
 
     // Get response before it's been PUT (should show pending)
-    let get_url = format!("{}/response/{}", base_url, request_id);
-    let (get_status, get_body) = http_get(&get_url);
+    let get_url = format!("/response/{request_id}");
+    let (get_status, get_body) = common::get(&app, &get_url).await;
 
     assert_eq!(get_status, 200);
 
@@ -266,17 +164,16 @@ fn test_response_pending_status() {
 }
 
 /// Test POST /response creates a standalone response
-#[test]
-fn test_create_standalone_response() {
-    let base_url = get_base_url();
+#[tokio::test]
+async fn test_create_standalone_response() {
+    let app = common::test_app().await;
 
     let payload = json!({
         "iv": "standalone_iv",
         "payload": "standalone_payload"
     });
 
-    let url = format!("{}/response", base_url);
-    let (status_code, body) = http_post(&url, &payload);
+    let (status_code, body) = common::post(&app, "/response", &payload).await;
 
     assert_eq!(status_code, 201);
 
@@ -286,9 +183,9 @@ fn test_create_standalone_response() {
 }
 
 /// Test standalone response flow: POST /response then GET /response/:id
-#[test]
-fn test_standalone_response_flow() {
-    let base_url = get_base_url();
+#[tokio::test]
+async fn test_standalone_response_flow() {
+    let app = common::test_app().await;
 
     // Create standalone response
     let payload = json!({
@@ -296,16 +193,15 @@ fn test_standalone_response_flow() {
         "payload": "standalone_flow_payload"
     });
 
-    let create_url = format!("{}/response", base_url);
-    let (status_code, body) = http_post(&create_url, &payload);
+    let (status_code, body) = common::post(&app, "/response", &payload).await;
     assert_eq!(status_code, 201);
 
     let create_json: Value = serde_json::from_str(&body).expect("Failed to parse JSON");
     let request_id = create_json["request_id"].as_str().unwrap();
 
     // Retrieve the response
-    let get_url = format!("{}/response/{}", base_url, request_id);
-    let (get_status, get_body) = http_get(&get_url);
+    let get_url = format!("/response/{request_id}");
+    let (get_status, get_body) = common::get(&app, &get_url).await;
 
     assert_eq!(get_status, 200);
 
@@ -316,40 +212,38 @@ fn test_standalone_response_flow() {
 }
 
 /// Test invalid request ID returns 404
-#[test]
-fn test_invalid_request_id() {
-    let base_url = get_base_url();
-    let url = format!("{}/request/00000000-0000-0000-0000-000000000000", base_url);
-    let (status_code, _) = http_get(&url);
+#[tokio::test]
+async fn test_invalid_request_id() {
+    let app = common::test_app().await;
+    let (status_code, _) = common::get(&app, "/request/00000000-0000-0000-0000-000000000000").await;
 
     assert_eq!(status_code, 404);
 }
 
 /// Test invalid response ID returns appropriate error
-#[test]
-fn test_invalid_response_id() {
-    let base_url = get_base_url();
-    let url = format!("{}/response/00000000-0000-0000-0000-000000000000", base_url);
-    let (status_code, _) = http_get(&url);
+#[tokio::test]
+async fn test_invalid_response_id() {
+    let app = common::test_app().await;
+    let (status_code, _) =
+        common::get(&app, "/response/00000000-0000-0000-0000-000000000000").await;
 
     // Should return 404 or an error status
-    assert!(status_code == 404 || (status_code >= 400 && status_code < 500));
+    assert!(status_code == 404 || (400..500).contains(&status_code));
 }
 
 /// Test that request requires both iv and payload fields
-#[test]
-fn test_create_request_validation() {
-    let base_url = get_base_url();
+#[tokio::test]
+async fn test_create_request_validation() {
+    let app = common::test_app().await;
 
     // Missing payload field
     let invalid_payload = json!({
         "iv": "test_iv"
     });
 
-    let url = format!("{}/request", base_url);
-    let (status_code, _) = http_post(&url, &invalid_payload);
+    let (status_code, _) = common::post(&app, "/request", &invalid_payload).await;
 
-    assert!(status_code >= 400 && status_code < 500);
+    assert!((400..500).contains(&status_code));
 }
 
 // ---------------------------------------------------------------------------
@@ -364,95 +258,86 @@ fn fresh_id() -> String {
     format!("{}{}", Uuid::new_v4().simple(), Uuid::new_v4().simple())
 }
 
-#[test]
-fn test_create_request_with_client_supplied_id() {
-    let base_url = get_base_url();
+#[tokio::test]
+async fn test_create_request_with_client_supplied_id() {
+    let app = common::test_app().await;
     let id = fresh_id();
     let body = json!({
         "request_id": id,
         "iv": "iv-for-custom-id",
         "payload": "payload-for-custom-id",
     });
-    let (s, b) = http_post(&format!("{base_url}/request"), &body);
+    let (s, b) = common::post(&app, "/request", &body).await;
     assert_eq!(s, 200, "POST /request with custom id should succeed: {b}");
     let v: Value = serde_json::from_str(&b).unwrap();
     assert_eq!(v["request_id"], id, "response echoes the supplied id");
 
-    let (gs, gb) = http_get(&format!("{base_url}/request/{id}"));
+    let (gs, gb) = common::get(&app, &format!("/request/{id}")).await;
     assert_eq!(gs, 200, "GET /request/<custom> should retrieve the payload");
     let gv: Value = serde_json::from_str(&gb).unwrap();
     assert_eq!(gv["iv"], "iv-for-custom-id");
     assert_eq!(gv["payload"], "payload-for-custom-id");
 
     // GETDEL semantics — second GET 404s.
-    let (gs2, _) = http_get(&format!("{base_url}/request/{id}"));
+    let (gs2, _) = common::get(&app, &format!("/request/{id}")).await;
     assert_eq!(gs2, 404);
 }
 
-#[test]
-fn test_create_request_with_duplicate_id_returns_409() {
-    let base_url = get_base_url();
+#[tokio::test]
+async fn test_create_request_with_duplicate_id_returns_409() {
+    let app = common::test_app().await;
     let id = fresh_id();
     let body = json!({"request_id": id, "iv": "x", "payload": "y"});
 
-    let (s1, _) = http_post(&format!("{base_url}/request"), &body);
+    let (s1, _) = common::post(&app, "/request", &body).await;
     assert_eq!(s1, 200);
 
-    let (s2, _) = http_post(&format!("{base_url}/request"), &body);
+    let (s2, _) = common::post(&app, "/request", &body).await;
     assert_eq!(s2, 409, "second POST with same request_id must 409");
 }
 
 // ---------------------------------------------------------------------------
 // Server-driven URL overrides. The bridge takes no `app_id` input — it returns
-// the whole `app_overrides` map blindly and the SDK picks its own entry.
-//
-// These tests require the bridge to be started with this exact fixture in the
-// `APP_URL_OVERRIDES` env var (CI and the README do this):
-//
-//   {"app_integration_override_fixture":
-//      {"app_clip_bundle_id":"org.example.integration.Clip",
-//       "verify_url":"https://world.org/verify"}}
+// the whole `app_overrides` map blindly and the SDK picks its own entry. The
+// harness injects the fixture directly into the router (see `common`), so these
+// tests need no `APP_URL_OVERRIDES` env var.
 // ---------------------------------------------------------------------------
 
-const FIXTURE_APP_ID: &str = "app_integration_override_fixture";
-const FIXTURE_APP_CLIP_BUNDLE_ID: &str = "org.example.integration.Clip";
-const FIXTURE_VERIFY_URL: &str = "https://world.org/verify";
-
-#[test]
-fn test_response_includes_full_override_map() {
-    let base_url = get_base_url();
+#[tokio::test]
+async fn test_response_includes_full_override_map() {
+    let app = common::test_app().await;
     // Opt in — the bridge only returns overrides to clients that advertise support.
     let body = json!({"iv": "x", "payload": "y", "supports_app_overrides": true});
 
-    let (s, b) = http_post(&format!("{base_url}/request"), &body);
+    let (s, b) = common::post(&app, "/request", &body).await;
     assert_eq!(s, 200, "POST /request should succeed: {b}");
 
     let v: Value = serde_json::from_str(&b).unwrap();
     let entry = v
         .get("app_overrides")
-        .and_then(|m| m.get(FIXTURE_APP_ID))
-        .unwrap_or_else(|| panic!("app_overrides map must contain the fixture entry. Is APP_URL_OVERRIDES set to the test fixture? Got: {b}"));
+        .and_then(|m| m.get(common::FIXTURE_APP_ID))
+        .unwrap_or_else(|| panic!("app_overrides map must contain the fixture entry: {b}"));
 
     assert_eq!(
         entry.get("app_clip_bundle_id").and_then(Value::as_str),
-        Some(FIXTURE_APP_CLIP_BUNDLE_ID),
+        Some(common::FIXTURE_APP_CLIP_BUNDLE_ID),
         "fixture entry must carry the configured app_clip_bundle_id: {b}"
     );
     assert_eq!(
         entry.get("verify_url").and_then(Value::as_str),
-        Some(FIXTURE_VERIFY_URL),
+        Some(common::FIXTURE_VERIFY_URL),
         "fixture entry must carry the configured verify_url: {b}"
     );
 }
 
-#[test]
-fn test_request_id_still_present_alongside_overrides() {
+#[tokio::test]
+async fn test_request_id_still_present_alongside_overrides() {
     // The override map is additive — the core request_id contract is unchanged,
     // so an SDK that ignores app_overrides still works exactly as before.
-    let base_url = get_base_url();
+    let app = common::test_app().await;
     let body = json!({"iv": "x", "payload": "y", "supports_app_overrides": true});
 
-    let (s, b) = http_post(&format!("{base_url}/request"), &body);
+    let (s, b) = common::post(&app, "/request", &body).await;
     assert_eq!(s, 200, "POST /request should succeed: {b}");
 
     let v: Value = serde_json::from_str(&b).unwrap();
@@ -463,12 +348,12 @@ fn test_request_id_still_present_alongside_overrides() {
     );
 }
 
-#[test]
-fn test_response_omits_overrides_without_opt_in() {
-    let base_url = get_base_url();
+#[tokio::test]
+async fn test_response_omits_overrides_without_opt_in() {
+    let app = common::test_app().await;
     let body = json!({"iv": "x", "payload": "y"});
 
-    let (s, b) = http_post(&format!("{base_url}/request"), &body);
+    let (s, b) = common::post(&app, "/request", &body).await;
     assert_eq!(s, 200, "POST /request should succeed: {b}");
 
     let v: Value = serde_json::from_str(&b).unwrap();
@@ -482,12 +367,12 @@ fn test_response_omits_overrides_without_opt_in() {
     );
 }
 
-#[test]
-fn test_create_request_without_id_still_generates_uuid() {
-    let base_url = get_base_url();
+#[tokio::test]
+async fn test_create_request_without_id_still_generates_uuid() {
+    let app = common::test_app().await;
     let body = json!({"iv": "no-id-iv", "payload": "no-id-payload"});
 
-    let (s, b) = http_post(&format!("{base_url}/request"), &body);
+    let (s, b) = common::post(&app, "/request", &body).await;
     assert_eq!(s, 200);
     let v: Value = serde_json::from_str(&b).unwrap();
     let id = v["request_id"].as_str().expect("request_id");
@@ -496,62 +381,62 @@ fn test_create_request_without_id_still_generates_uuid() {
     assert_eq!(id.matches('-').count(), 4);
 }
 
-#[test]
-fn test_create_request_rejects_invalid_request_id_chars() {
-    let base_url = get_base_url();
+#[tokio::test]
+async fn test_create_request_rejects_invalid_request_id_chars() {
+    let app = common::test_app().await;
     let body = json!({
         "request_id": "has spaces and / slashes",
         "iv": "x",
         "payload": "y",
     });
-    let (s, _) = http_post(&format!("{base_url}/request"), &body);
+    let (s, _) = common::post(&app, "/request", &body).await;
     assert_eq!(s, 400, "invalid request_id chars must 400");
 }
 
-#[test]
-fn test_create_request_rejects_too_long_request_id() {
-    let base_url = get_base_url();
+#[tokio::test]
+async fn test_create_request_rejects_too_long_request_id() {
+    let app = common::test_app().await;
     let body = json!({
         "request_id": "a".repeat(257),
         "iv": "x",
         "payload": "y",
     });
-    let (s, _) = http_post(&format!("{base_url}/request"), &body);
+    let (s, _) = common::post(&app, "/request", &body).await;
     assert_eq!(s, 400, "request_id over 256 chars must 400");
 }
 
-#[test]
-fn test_create_request_rejects_too_short_request_id() {
-    let base_url = get_base_url();
+#[tokio::test]
+async fn test_create_request_rejects_too_short_request_id() {
+    let app = common::test_app().await;
     let body = json!({
         "request_id": "shortid",
         "iv": "x",
         "payload": "y",
     });
-    let (s, _) = http_post(&format!("{base_url}/request"), &body);
+    let (s, _) = common::post(&app, "/request", &body).await;
     assert_eq!(s, 400, "request_id under 16 chars must 400");
 }
 
-#[test]
-fn test_create_request_rejects_colon_in_request_id() {
+#[tokio::test]
+async fn test_create_request_rejects_colon_in_request_id() {
     // Colon is excluded from the charset — `status:foo` would round-trip into
     // the Redis key `req:status:foo`, colliding with the bridge's own status
     // namespace. Excluding `:` prevents the overlap by construction.
-    let base_url = get_base_url();
+    let app = common::test_app().await;
     let body = json!({
         "request_id": "status:colliding-id-here",
         "iv": "x",
         "payload": "y",
     });
-    let (s, _) = http_post(&format!("{base_url}/request"), &body);
+    let (s, _) = common::post(&app, "/request", &body).await;
     assert_eq!(s, 400, "request_id containing `:` must 400");
 }
 
-#[test]
-fn test_get_request_malformed_path_returns_400() {
-    let base_url = get_base_url();
+#[tokio::test]
+async fn test_get_request_malformed_path_returns_400() {
+    let app = common::test_app().await;
     // 3-char path param fails the min-length check.
-    let (s, _) = http_get(&format!("{base_url}/request/abc"));
+    let (s, _) = common::get(&app, "/request/abc").await;
     assert_eq!(s, 400, "GET /request/<too-short> must 400, not 404");
 }
 
@@ -562,14 +447,14 @@ fn test_get_request_malformed_path_returns_400() {
 
 /// Supplying an uppercase `request_id` on POST /request — the response echoes
 /// it back as lowercase and the key is stored lowercase.
-#[test]
-fn test_create_request_uppercase_id_is_normalized() {
-    let base_url = get_base_url();
+#[tokio::test]
+async fn test_create_request_uppercase_id_is_normalized() {
+    let app = common::test_app().await;
     let id_lower = fresh_id();
     let id_upper = id_lower.to_uppercase();
 
     let body = json!({"request_id": id_upper, "iv": "iv-upper", "payload": "payload-upper"});
-    let (s, b) = http_post(&format!("{base_url}/request"), &body);
+    let (s, b) = common::post(&app, "/request", &body).await;
     assert_eq!(s, 200, "POST with uppercase request_id should succeed: {b}");
 
     let v: Value = serde_json::from_str(&b).unwrap();
@@ -579,7 +464,7 @@ fn test_create_request_uppercase_id_is_normalized() {
     );
 
     // Retrieve using the lowercase id — must find the stored payload.
-    let (gs, gb) = http_get(&format!("{base_url}/request/{id_lower}"));
+    let (gs, gb) = common::get(&app, &format!("/request/{id_lower}")).await;
     assert_eq!(gs, 200, "GET with lowercase id must find the payload");
     let gv: Value = serde_json::from_str(&gb).unwrap();
     assert_eq!(gv["iv"], "iv-upper");
@@ -587,19 +472,19 @@ fn test_create_request_uppercase_id_is_normalized() {
 
 /// GET /request/:id with an uppercase path param finds the key stored by its
 /// lowercase equivalent (normalization happens at the path layer too).
-#[test]
-fn test_get_request_uppercase_path_param_is_normalized() {
-    let base_url = get_base_url();
+#[tokio::test]
+async fn test_get_request_uppercase_path_param_is_normalized() {
+    let app = common::test_app().await;
     let id_lower = fresh_id();
 
     // Store using lowercase id.
     let body = json!({"request_id": id_lower, "iv": "iv-path", "payload": "payload-path"});
-    let (s, _) = http_post(&format!("{base_url}/request"), &body);
+    let (s, _) = common::post(&app, "/request", &body).await;
     assert_eq!(s, 200);
 
     // Retrieve using uppercase path param — must hit the same key.
     let id_upper = id_lower.to_uppercase();
-    let (gs, gb) = http_get(&format!("{base_url}/request/{id_upper}"));
+    let (gs, gb) = common::get(&app, &format!("/request/{id_upper}")).await;
     assert_eq!(
         gs, 200,
         "GET with uppercase path param must find the payload"
@@ -611,28 +496,28 @@ fn test_get_request_uppercase_path_param_is_normalized() {
 
 /// Full round-trip: POST with uppercase id, PUT response via uppercase path,
 /// GET response via lowercase path — all resolve to the same key.
-#[test]
-fn test_case_insensitive_full_round_trip() {
-    let base_url = get_base_url();
+#[tokio::test]
+async fn test_case_insensitive_full_round_trip() {
+    let app = common::test_app().await;
     let id_lower = fresh_id();
     let id_upper = id_lower.to_uppercase();
 
     // Create request with uppercase id.
     let req_body = json!({"request_id": id_upper, "iv": "rt-iv", "payload": "rt-payload"});
-    let (s, _) = http_post(&format!("{base_url}/request"), &req_body);
+    let (s, _) = common::post(&app, "/request", &req_body).await;
     assert_eq!(s, 200);
 
     // Consume the request (GET) with mixed path — verifies normalization at GET.
-    let (gs, _) = http_get(&format!("{base_url}/request/{id_upper}"));
+    let (gs, _) = common::get(&app, &format!("/request/{id_upper}")).await;
     assert_eq!(gs, 200);
 
     // PUT response using uppercase path param.
     let res_body = json!({"iv": "rt-resp-iv", "payload": "rt-resp-payload"});
-    let (ps, _) = http_put(&format!("{base_url}/response/{id_upper}"), &res_body);
+    let (ps, _) = common::put(&app, &format!("/response/{id_upper}"), &res_body).await;
     assert_eq!(ps, 201, "PUT /response with uppercase id must succeed");
 
     // GET response using lowercase path param.
-    let (rgs, rgb) = http_get(&format!("{base_url}/response/{id_lower}"));
+    let (rgs, rgb) = common::get(&app, &format!("/response/{id_lower}")).await;
     assert_eq!(
         rgs, 200,
         "GET /response with lowercase id must find the response"
@@ -643,11 +528,10 @@ fn test_case_insensitive_full_round_trip() {
 }
 
 /// Test OpenAPI documentation endpoint exists
-#[test]
-fn test_openapi_endpoint() {
-    let base_url = get_base_url();
-    let url = format!("{}/openapi.json", base_url);
-    let (status_code, body) = http_get(&url);
+#[tokio::test]
+async fn test_openapi_endpoint() {
+    let app = common::test_app().await;
+    let (status_code, body) = common::get(&app, "/openapi.json").await;
 
     assert_eq!(status_code, 200);
 


### PR DESCRIPTION
### Changes
- Improves the documentation and rationale of this service.
- Creates an AGENTS to point into how this project should be developed and flag common pitfalls.
- Removes client-specific documentation.
- Updates CODEOWNERs.
- Starts renaming to `message-bridge` (internal changes) as wallet bridge is a misnomer.
- Refactors integration tests to not require manually running the server binary.