### PR TITLE
feat: add idkit flow id interface

### DIFF
--- a/src/routes/request.rs
+++ b/src/routes/request.rs
@@ -22,6 +22,8 @@ use crate::utils::{
 };
 
 const REQ_PREFIX: &str = "req:";
+/// If this header is present and to `true`, the GET /request will include an `idkit_flow_id` for telemetry correlation
+/// We're adding this header to avoid breaking existing client that don't expect this field in the response
 const ACCEPT_IDKIT_FLOW_ID_HEADER: &str = "accept-idkit-flow-id";
 const IDKIT_FLOW_ID_PREFIX: &str = "idkitflow_";
 
@@ -81,7 +83,7 @@ struct RequestResponse {
     /// The opaque encrypted request payload.
     #[serde(flatten)]
     payload: RequestPayload,
-    /// Correlates this handoff with compatible client telemetry.
+    /// Only present when the client explicitly opts in via the `accept-idkit-flow-id` header.
     #[serde(skip_serializing_if = "Option::is_none")]
     idkit_flow_id: Option<String>,
 }
@@ -179,6 +181,7 @@ async fn get_request(
     let payload: RequestPayload =
         serde_json::from_slice(&value).map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
+    // TODO: use this for telemetry in the bridge PR #103
     let idkit_flow_id = accepts_idkit_flow_id(&headers)
         .then(|| format!("{IDKIT_FLOW_ID_PREFIX}{}", Uuid::new_v4()));
 

--- a/src/routes/request.rs
+++ b/src/routes/request.rs
@@ -4,7 +4,7 @@ use aide::axum::{
 };
 use axum::{
     extract::Path,
-    http::{Method, StatusCode},
+    http::{HeaderMap, Method, StatusCode},
     Extension,
 };
 use axum_jsonschema::Json;
@@ -22,6 +22,8 @@ use crate::utils::{
 };
 
 const REQ_PREFIX: &str = "req:";
+const ACCEPT_IDKIT_FLOW_ID_HEADER: &str = "accept-idkit-flow-id";
+const IDKIT_FLOW_ID_PREFIX: &str = "idkitflow_";
 
 #[derive(Debug, serde::Deserialize, JsonSchema)]
 struct CreateRequestBody {
@@ -74,11 +76,21 @@ struct RequestCreatedPayload {
     app_overrides: AppOverrides,
 }
 
+#[derive(Debug, serde::Serialize, JsonSchema)]
+struct RequestResponse {
+    /// The opaque encrypted request payload.
+    #[serde(flatten)]
+    payload: RequestPayload,
+    /// Correlates this handoff with compatible client telemetry.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    idkit_flow_id: Option<String>,
+}
+
 pub fn handler() -> ApiRouter {
     let cors = CorsLayer::new()
         .allow_origin(Any)
         .allow_headers(AllowHeaders::any())
-        .allow_methods([Method::POST, Method::HEAD, Method::PUT]);
+        .allow_methods([Method::GET, Method::POST, Method::HEAD, Method::PUT]);
 
     let environment = env::var("ENVIRONMENT")
         .unwrap_or_else(|_| "unknown".to_string())
@@ -125,7 +137,8 @@ async fn has_request(
 async fn get_request(
     Path(request_id): Path<String>,
     Extension(mut redis): Extension<ConnectionManager>,
-) -> Result<Json<RequestPayload>, StatusCode> {
+    headers: HeaderMap,
+) -> Result<Json<RequestResponse>, StatusCode> {
     let request_id = request_id.to_lowercase();
     if validate_request_id(&request_id).is_err() {
         return Err(StatusCode::BAD_REQUEST);
@@ -163,9 +176,27 @@ async fn get_request(
         RequestStatus::Retrieved
     );
 
-    serde_json::from_slice(&value).map_or(Err(StatusCode::INTERNAL_SERVER_ERROR), |value| {
-        Ok(Json(value))
-    })
+    let payload: RequestPayload =
+        serde_json::from_slice(&value).map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    let idkit_flow_id = accepts_idkit_flow_id(&headers)
+        .then(|| format!("{IDKIT_FLOW_ID_PREFIX}{}", Uuid::new_v4()));
+
+    Ok(Json(RequestResponse {
+        payload,
+        idkit_flow_id,
+    }))
+}
+
+/// Treat the opt-in header as enabled only for the explicit value `true`.
+///
+/// Header names are case-insensitive; the value comparison is also
+/// case-insensitive for compatibility with common HTTP clients.
+fn accepts_idkit_flow_id(headers: &HeaderMap) -> bool {
+    headers
+        .get(ACCEPT_IDKIT_FLOW_ID_HEADER)
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|value| value.eq_ignore_ascii_case("true"))
 }
 
 /// Create a new request. Optionally accepts a client-supplied `request_id`

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -54,7 +54,20 @@ async fn send(
     route: &str,
     body: Option<&Value>,
 ) -> (u16, String) {
-    let builder = Request::builder().uri(route).method(method);
+    send_with_headers(app, method, route, body, &[]).await
+}
+
+async fn send_with_headers(
+    app: &axum::Router,
+    method: Method,
+    route: &str,
+    body: Option<&Value>,
+    headers: &[(&str, &str)],
+) -> (u16, String) {
+    let mut builder = Request::builder().uri(route).method(method);
+    for (name, value) in headers {
+        builder = builder.header(*name, *value);
+    }
     let request = match body {
         Some(json) => builder
             .header("Content-Type", "application/json")
@@ -83,6 +96,15 @@ async fn send(
 
 pub async fn get(app: &axum::Router, route: &str) -> (u16, String) {
     send(app, Method::GET, route, None).await
+}
+
+pub async fn get_with_header(
+    app: &axum::Router,
+    route: &str,
+    name: &str,
+    value: &str,
+) -> (u16, String) {
+    send_with_headers(app, Method::GET, route, None, &[(name, value)]).await
 }
 
 pub async fn post(app: &axum::Router, route: &str, body: &Value) -> (u16, String) {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -61,10 +61,73 @@ async fn test_get_request_one_time_use() {
     let first_json: Value = serde_json::from_str(&first_body).expect("Failed to parse JSON");
     assert_eq!(first_json["iv"], "get_test_iv");
     assert_eq!(first_json["payload"], "get_test_payload");
+    assert!(
+        first_json.get("idkit_flow_id").is_none(),
+        "legacy response shape must omit the flow ID without an opt-in header"
+    );
 
     // Second GET should fail (one-time use)
     let (second_status, _) = common::get(&app, &get_url).await;
     assert_eq!(second_status, 404);
+}
+
+#[tokio::test]
+async fn test_get_request_returns_flow_id_when_client_opts_in() {
+    let app = common::test_app().await;
+    let payload = json!({
+        "iv": "flow_test_iv",
+        "payload": "flow_test_payload"
+    });
+
+    let (status_code, body) = common::post(&app, "/request", &payload).await;
+    assert_eq!(status_code, 200);
+
+    let create_json: Value = serde_json::from_str(&body).expect("Failed to parse JSON");
+    let request_id = create_json["request_id"].as_str().unwrap();
+    let get_url = format!("/request/{request_id}");
+
+    let (get_status, get_body) =
+        common::get_with_header(&app, &get_url, "Accept-IDKit-Flow-ID", "true").await;
+
+    assert_eq!(get_status, 200);
+
+    let response: Value = serde_json::from_str(&get_body).expect("Failed to parse JSON");
+    assert_eq!(response["iv"], "flow_test_iv");
+    assert_eq!(response["payload"], "flow_test_payload");
+
+    let flow_id = response["idkit_flow_id"]
+        .as_str()
+        .expect("opted-in response must include a flow ID");
+    let uuid = flow_id
+        .strip_prefix("idkitflow_")
+        .expect("flow ID must use the IDKit prefix");
+    assert!(Uuid::parse_str(uuid).is_ok());
+}
+
+#[tokio::test]
+async fn test_get_request_requires_true_flow_id_header_value() {
+    let app = common::test_app().await;
+    let payload = json!({
+        "iv": "flow_false_iv",
+        "payload": "flow_false_payload"
+    });
+
+    let (status_code, body) = common::post(&app, "/request", &payload).await;
+    assert_eq!(status_code, 200);
+
+    let create_json: Value = serde_json::from_str(&body).expect("Failed to parse JSON");
+    let request_id = create_json["request_id"].as_str().unwrap();
+    let get_url = format!("/request/{request_id}");
+    let (get_status, get_body) =
+        common::get_with_header(&app, &get_url, "Accept-IDKit-Flow-ID", "false").await;
+
+    assert_eq!(get_status, 200);
+
+    let response: Value = serde_json::from_str(&get_body).expect("Failed to parse JSON");
+    assert!(
+        response.get("idkit_flow_id").is_none(),
+        "non-true header values must preserve the legacy response shape"
+    );
 }
 
 /// Test PUT /response/:id stores a response for a request


### PR DESCRIPTION
This PR adds the minimal client-facing IDKit flow ID contract without Redis correlation state.

- accepts `Accept-IDKit-Flow-ID: true` on `GET /request/:request_id`
- returns `{iv, payload, idkit_flow_id}` only for opted-in callers
- generates the prefixed ID at successful one-time handoff while preserving the legacy response shape
- allows GET in CORS preflight and adds positive and negative integration coverage

Validation:
- `cargo fmt -- --check`
- `cargo clippy --all-features`
- `cargo build --locked`
- `cargo test` (28 integration tests)