### PR TITLE
MCORE-1832: Mint idkit_flow_id at request creation; emit handoff telemetry

### DIFF
--- a/src/flow.rs
+++ b/src/flow.rs
@@ -1,0 +1,276 @@
+//! `IDKit` flow tracing: minting, persistence, and telemetry emission.
+//!
+//! The bridge mints an `idkit_flow_id` when a request is created and stores it
+//! in Redis (`flow:<request_id>`) alongside the request itself, with the same
+//! uniform TTL. The `request_id -> idkit_flow_id` mapping lives *only* in
+//! Redis: the sanitized spans emitted here carry the flow id but never the
+//! request id, raw URL paths, or payload contents, so the two identifiers
+//! cannot be joined outside the bridge. Metrics carry only bounded tags
+//! (`environment`, `leg`) — never the flow id.
+//!
+//! Everything in this module is best-effort telemetry: failures are logged and
+//! swallowed so the payload handoff path never fails because of tracing.
+//!
+//! The four spans are separate short traces correlated by `idkit_flow_id`, not
+//! one long-lived trace. The handoff *durations* live in the
+//! `wallet_bridge.handoff.duration_ms` distribution:
+//! - `leg:request` — durable request storage to successful consumption. This
+//!   includes QR/deep-link and user-open time, so it is a handoff-freshness
+//!   signal rather than HTTP server latency.
+//! - `leg:response` — durable response storage to the poll that consumes it,
+//!   which includes the `IDKit` poll interval.
+
+use std::sync::OnceLock;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use redis::{aio::ConnectionManager, AsyncCommands};
+use serde::{Deserialize, Serialize};
+use telemetry_batteries::reexports::metrics;
+use tracing::Instrument;
+use uuid::Uuid;
+
+use crate::utils::EXPIRE_AFTER_SECONDS;
+
+/// Redis key prefix for flow metadata. Disjoint from `req:`/`res:` so the
+/// GETDEL single-use semantics of the payload keys are untouched.
+pub const FLOW_PREFIX: &str = "flow:";
+/// Prefix on every minted flow id, so the identifier is self-describing when
+/// it shows up in spans or downstream telemetry.
+pub const IDKIT_FLOW_ID_PREFIX: &str = "idkitflow_";
+
+const HANDOFF_METRIC: &str = "wallet_bridge.handoff.duration_ms";
+
+/// Flow metadata persisted next to a request for the lifetime of the flow.
+///
+/// Not part of any API schema — this is an internal Redis value. Timestamps
+/// are wall-clock epoch milliseconds; handoff durations are seconds-to-minutes
+/// (QR scan time, poll intervals), so NTP-level skew between pods is noise.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct FlowMetadata {
+    pub idkit_flow_id: String,
+    pub request_persisted_at_ms: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub response_persisted_at_ms: Option<u64>,
+}
+
+/// The Redis key holding [`FlowMetadata`] for a request.
+#[must_use]
+pub fn key(request_id: &str) -> String {
+    format!("{FLOW_PREFIX}{request_id}")
+}
+
+/// Mint a flow id and persist fresh metadata for a newly created request.
+///
+/// Called after the request payload is durably stored. Emits the
+/// `wallet_bridge.request.create` span and, on successful persistence, the
+/// `request_created` counter.
+pub async fn record_request_created(
+    redis: &mut ConnectionManager,
+    request_id: &str,
+    route: &'static str,
+    http_status: u64,
+) {
+    let flow = FlowMetadata {
+        idkit_flow_id: format!("{IDKIT_FLOW_ID_PREFIX}{}", Uuid::new_v4()),
+        request_persisted_at_ms: now_ms(),
+        response_persisted_at_ms: None,
+    };
+
+    let span = tracing::info_span!(
+        "wallet_bridge.request.create",
+        http.route = route,
+        http.status_code = http_status,
+        redis.outcome = tracing::field::Empty,
+        idkit_flow_id = %flow.idkit_flow_id,
+    );
+
+    async {
+        if write(redis, request_id, &flow).await {
+            increment("wallet_bridge.request_created");
+        }
+    }
+    .instrument(span)
+    .await;
+}
+
+/// Record the consumption of a request payload from its flow metadata.
+///
+/// The metadata bytes come from the caller's pipeline (no extra round trip).
+/// Returns the persisted flow id for the caller to surface to opted-in
+/// clients.
+///
+/// Emits the `wallet_bridge.request.consume` span, the `request_consumed`
+/// counter, and the `leg:request` handoff distribution. A missing or
+/// unparseable blob (expired, or written by a pre-flow bridge) skips all
+/// telemetry — the payload handoff itself already succeeded.
+pub fn record_request_consumed(flow_raw: Option<&[u8]>) -> Option<String> {
+    let flow = parse(flow_raw?)?;
+    let queue_age_ms = now_ms().saturating_sub(flow.request_persisted_at_ms);
+
+    tracing::info_span!(
+        "wallet_bridge.request.consume",
+        http.route = "/request/:request_id",
+        http.status_code = 200_u64,
+        queue_age_ms,
+        idkit_flow_id = %flow.idkit_flow_id,
+    );
+
+    record_handoff("request", queue_age_ms);
+    increment("wallet_bridge.request_consumed");
+
+    Some(flow.idkit_flow_id)
+}
+
+/// Stamp `response_persisted_at_ms` into the flow metadata and refresh its TTL,
+/// after a response payload is durably stored.
+///
+/// Emits the `wallet_bridge.response.create` span and, on successful
+/// persistence, the `response_created` counter. A missing flow key (expired,
+/// or a standalone response with no request leg) skips all telemetry.
+pub async fn record_response_created(redis: &mut ConnectionManager, request_id: &str) {
+    let raw: Option<Vec<u8>> = match redis.get(key(request_id)).await {
+        Ok(raw) => raw,
+        Err(e) => {
+            tracing::warn!("Failed to read flow metadata: {e}");
+            return;
+        }
+    };
+    let Some(mut flow) = raw.as_deref().and_then(parse) else {
+        return;
+    };
+    flow.response_persisted_at_ms = Some(now_ms());
+
+    let span = tracing::info_span!(
+        "wallet_bridge.response.create",
+        http.route = "/response/:request_id",
+        http.status_code = 201_u64,
+        redis.outcome = tracing::field::Empty,
+        idkit_flow_id = %flow.idkit_flow_id,
+    );
+
+    async {
+        if write(redis, request_id, &flow).await {
+            increment("wallet_bridge.response_created");
+        }
+    }
+    .instrument(span)
+    .await;
+}
+
+/// Consume (GETDEL) the flow metadata after a response payload is returned to
+/// the poller — the end of the flow's life.
+///
+/// Emits the `wallet_bridge.response.consume` span, the `response_consumed`
+/// counter, and the `leg:response` handoff distribution. The distribution is
+/// skipped if the response-creation stamp never landed (best-effort write
+/// failed earlier); the flow id itself is never returned to the RP.
+pub async fn record_response_consumed(redis: &mut ConnectionManager, request_id: &str) {
+    let raw: Option<Vec<u8>> = match redis.get_del(key(request_id)).await {
+        Ok(raw) => raw,
+        Err(e) => {
+            tracing::warn!("Failed to consume flow metadata: {e}");
+            return;
+        }
+    };
+    let Some(flow) = raw.as_deref().and_then(parse) else {
+        return;
+    };
+    let queue_age_ms = flow
+        .response_persisted_at_ms
+        .map(|persisted| now_ms().saturating_sub(persisted));
+
+    tracing::info_span!(
+        "wallet_bridge.response.consume",
+        http.route = "/response/:request_id",
+        http.status_code = 200_u64,
+        queue_age_ms,
+        idkit_flow_id = %flow.idkit_flow_id,
+    );
+
+    if let Some(duration) = queue_age_ms {
+        record_handoff("response", duration);
+    }
+    increment("wallet_bridge.response_consumed");
+}
+
+/// Add a read of the flow metadata plus a TTL refresh to an existing pipeline.
+///
+/// The refresh keeps the flow key alive for the response leg: `GET /request`
+/// already refreshes the status key TTL, and without a matching refresh here
+/// the flow key would expire mid-flow while the status key survives. The read
+/// lands as one `Option<Vec<u8>>` in the pipeline's result tuple (the expire
+/// is `ignore()`d).
+pub fn pipe_read_and_refresh(pipe: &mut redis::Pipeline, request_id: &str) {
+    let key = key(request_id);
+    pipe.get(&key);
+    pipe.expire(&key, ttl_seconds()).ignore();
+}
+
+/// Persist flow metadata under the uniform TTL. Returns whether the write
+/// landed; failures are logged, never propagated.
+async fn write(redis: &mut ConnectionManager, request_id: &str, flow: &FlowMetadata) -> bool {
+    let Ok(bytes) = serde_json::to_vec(flow) else {
+        tracing::warn!("Failed to serialize flow metadata");
+        record_outcome("error");
+        return false;
+    };
+    match redis
+        .set_ex::<_, _, ()>(key(request_id), bytes, EXPIRE_AFTER_SECONDS)
+        .await
+    {
+        Ok(()) => {
+            record_outcome("ok");
+            true
+        }
+        Err(e) => {
+            tracing::warn!("Failed to persist flow metadata: {e}");
+            record_outcome("error");
+            false
+        }
+    }
+}
+
+/// Record the `redis.outcome` attribute on the enclosing create span.
+fn record_outcome(outcome: &str) {
+    tracing::Span::current().record("redis.outcome", outcome);
+}
+
+fn parse(raw: &[u8]) -> Option<FlowMetadata> {
+    match serde_json::from_slice(raw) {
+        Ok(flow) => Some(flow),
+        Err(e) => {
+            tracing::warn!("Failed to parse flow metadata: {e}");
+            None
+        }
+    }
+}
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |d| u64::try_from(d.as_millis()).unwrap_or(u64::MAX))
+}
+
+fn ttl_seconds() -> i64 {
+    i64::try_from(EXPIRE_AFTER_SECONDS).unwrap_or(i64::MAX)
+}
+
+/// Deployment environment tag for metrics, from the `ENVIRONMENT` env var
+/// (mirroring the normalization in the request router).
+fn environment() -> &'static str {
+    static ENVIRONMENT: OnceLock<String> = OnceLock::new();
+    ENVIRONMENT.get_or_init(|| {
+        std::env::var("ENVIRONMENT")
+            .map_or_else(|_| "unknown".to_string(), |e| e.trim().to_lowercase())
+    })
+}
+
+fn increment(counter: &'static str) {
+    metrics::counter!(counter, "environment" => environment()).increment(1);
+}
+
+#[allow(clippy::cast_precision_loss)] // handoff durations sit far below 2^52 ms
+fn record_handoff(leg: &'static str, duration_ms: u64) {
+    metrics::histogram!(HANDOFF_METRIC, "leg" => leg, "environment" => environment())
+        .record(duration_ms as f64);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ use redis::aio::ConnectionManager;
 
 use crate::utils::AppOverrides;
 
+pub mod flow;
 pub mod routes;
 pub mod server;
 pub mod utils;

--- a/src/routes/request.rs
+++ b/src/routes/request.rs
@@ -16,6 +16,7 @@ use std::sync::Arc;
 use tower_http::cors::{AllowHeaders, Any, CorsLayer};
 use uuid::Uuid;
 
+use crate::flow;
 use crate::utils::{
     handle_redis_error, validate_request_id, AppOverrides, RequestPayload, RequestStatus,
     EXPIRE_AFTER_SECONDS, REQ_STATUS_PREFIX,
@@ -25,7 +26,6 @@ const REQ_PREFIX: &str = "req:";
 /// If this header is present and to `true`, the GET /request will include an `idkit_flow_id` for telemetry correlation
 /// We're adding this header to avoid breaking existing client that don't expect this field in the response
 const ACCEPT_IDKIT_FLOW_ID_HEADER: &str = "accept-idkit-flow-id";
-const IDKIT_FLOW_ID_PREFIX: &str = "idkitflow_";
 
 #[derive(Debug, serde::Deserialize, JsonSchema)]
 struct CreateRequestBody {
@@ -83,7 +83,10 @@ struct RequestResponse {
     /// The opaque encrypted request payload.
     #[serde(flatten)]
     payload: RequestPayload,
-    /// Only present when the client explicitly opts in via the `accept-idkit-flow-id` header.
+    /// The flow id minted when the request was created, for telemetry
+    /// correlation. Only present when the client explicitly opts in via the
+    /// `accept-idkit-flow-id` header *and* the flow metadata is still in Redis
+    /// (it can be missing if the best-effort write failed at create time).
     #[serde(skip_serializing_if = "Option::is_none")]
     idkit_flow_id: Option<String>,
 }
@@ -146,12 +149,15 @@ async fn get_request(
         return Err(StatusCode::BAD_REQUEST);
     }
 
-    // Use a transaction to get both status and request data atomically
+    // Use a transaction to get both status and request data atomically.
+    // The flow metadata rides along: read for telemetry, TTL refreshed so it
+    // survives until the response leg (mirroring the status-key refresh below).
     let mut pipe = redis::pipe();
     pipe.get(format!("{REQ_STATUS_PREFIX}{request_id}"))
         .get_del(format!("{REQ_PREFIX}{request_id}"));
+    flow::pipe_read_and_refresh(&mut pipe, &request_id);
 
-    let (status, value): (Option<String>, Option<Vec<u8>>) = pipe
+    let (status, value, flow_raw): (Option<String>, Option<Vec<u8>>, Option<Vec<u8>>) = pipe
         .query_async(&mut redis)
         .await
         .map_err(handle_redis_error)?;
@@ -181,9 +187,10 @@ async fn get_request(
     let payload: RequestPayload =
         serde_json::from_slice(&value).map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
-    // TODO: use this for telemetry in the bridge PR #103
-    let idkit_flow_id = accepts_idkit_flow_id(&headers)
-        .then(|| format!("{IDKIT_FLOW_ID_PREFIX}{}", Uuid::new_v4()));
+    // Telemetry always fires on consumption; the header only gates whether the
+    // persisted flow id is surfaced to the client.
+    let idkit_flow_id = flow::record_request_consumed(flow_raw.as_deref())
+        .filter(|_| accepts_idkit_flow_id(&headers));
 
     Ok(Json(RequestResponse {
         payload,
@@ -209,14 +216,7 @@ async fn insert_request(
     Extension(app_overrides): Extension<Arc<AppOverrides>>,
     Json(body): Json<CreateRequestBody>,
 ) -> Result<Json<RequestCreatedPayload>, StatusCode> {
-    let request_id = match body.request_id {
-        Some(id) => {
-            let id = id.to_lowercase();
-            validate_request_id(&id)?;
-            id
-        }
-        None => Uuid::new_v4().to_string(),
-    };
+    let request_id = resolve_request_id(body.request_id)?;
 
     tracing::info!("Processing /request: {request_id}");
 
@@ -252,12 +252,27 @@ async fn insert_request(
         RequestStatus::Initialized
     );
 
+    flow::record_request_created(&mut redis, &request_id, "/request", 200).await;
+
     tracing::info!("Successfully processed /request: {request_id}");
 
     Ok(Json(RequestCreatedPayload {
         request_id,
         app_overrides: select_response_overrides(body.supports_app_overrides, &app_overrides),
     }))
+}
+
+/// Resolve the id for a new request: the validated, lowercased client-supplied
+/// value if present, otherwise a fresh UUID v4.
+fn resolve_request_id(supplied: Option<String>) -> Result<String, StatusCode> {
+    match supplied {
+        Some(id) => {
+            let id = id.to_lowercase();
+            validate_request_id(&id)?;
+            Ok(id)
+        }
+        None => Ok(Uuid::new_v4().to_string()),
+    }
 }
 
 /// Pick the overrides to echo back on `POST /request`: the configured map for
@@ -308,6 +323,9 @@ async fn put_request(
         )
         .await
         .map_err(handle_redis_error)?;
+
+    // Re-mint on every PUT: overwriting the payload starts a new flow.
+    flow::record_request_created(&mut redis, &request_id, "/request/:request_id", 201).await;
 
     tracing::info!("Successfully PUT /request: {request_id}");
 

--- a/src/routes/response.rs
+++ b/src/routes/response.rs
@@ -16,6 +16,7 @@ use std::str;
 use tower_http::cors::{AllowHeaders, Any, CorsLayer};
 use uuid::Uuid;
 
+use crate::flow;
 use crate::utils::{
     handle_redis_error, validate_request_id, RequestPayload, RequestStatus, EXPIRE_AFTER_SECONDS,
     REQ_STATUS_PREFIX,
@@ -92,6 +93,11 @@ async fn get_response(
                 "Failed to delete status for {request_id} after response retrieval: {e}"
             );
         }
+
+        // End of the flow: consume (GETDEL) the flow metadata and emit the
+        // response-leg handoff telemetry. The flow id is never returned to
+        // the RP. Pending polls (no payload yet) never reach this point.
+        flow::record_response_consumed(&mut redis, &request_id).await;
 
         return serde_json::from_slice(&value).map_or(
             Err(StatusCode::INTERNAL_SERVER_ERROR),
@@ -180,6 +186,10 @@ async fn insert_response(
     if set_ok.is_none() {
         return Err(StatusCode::CONFLICT);
     }
+
+    // Stamp the response-persisted timestamp into the flow metadata and
+    // refresh its TTL, now that the response is durably stored.
+    flow::record_response_created(&mut redis, &request_id).await;
 
     tracing::info!(
         "Request {request_id} state transition: {} -> {}",

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -34,6 +34,12 @@ fn fixture_overrides() -> AppOverrides {
     overrides
 }
 
+/// Direct Redis handle for tests that assert on the bridge's internal keys
+/// (e.g. `flow:<request_id>` metadata).
+pub async fn redis() -> ConnectionManager {
+    redis_connection().await
+}
+
 async fn redis_connection() -> ConnectionManager {
     let url = std::env::var("REDIS_URL").unwrap_or_else(|_| "redis://127.0.0.1:6379".to_string());
     let client = redis::Client::open(url).expect("REDIS_URL must be a valid Redis URL");

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,3 +1,4 @@
+use redis::AsyncCommands;
 use serde_json::{json, Value};
 use uuid::Uuid;
 
@@ -600,4 +601,169 @@ async fn test_openapi_endpoint() {
 
     let json: Value = serde_json::from_str(&body).expect("Failed to parse JSON");
     assert!(json.get("openapi").is_some());
+}
+
+/// The flow id is minted at POST /request time and persisted in Redis under
+/// `flow:<request_id>`; the consuming GET returns exactly that persisted id
+/// (not a fresh mint), and the flow key survives request consumption so the
+/// response leg can be correlated.
+#[tokio::test]
+async fn test_flow_id_minted_at_create_and_stable_through_get() {
+    let app = common::test_app().await;
+    let mut redis = common::redis().await;
+
+    let (status, body) = common::post(&app, "/request", &json!({"iv": "a", "payload": "b"})).await;
+    assert_eq!(status, 200);
+    let create_json: Value = serde_json::from_str(&body).expect("Failed to parse JSON");
+    let request_id = create_json["request_id"].as_str().unwrap().to_string();
+
+    let raw: Option<Vec<u8>> = redis.get(format!("flow:{request_id}")).await.unwrap();
+    let stored: Value =
+        serde_json::from_slice(&raw.expect("flow metadata must be persisted at create")).unwrap();
+    let stored_flow_id = stored["idkit_flow_id"].as_str().unwrap().to_string();
+    assert!(stored_flow_id.starts_with("idkitflow_"));
+    assert!(stored["request_persisted_at_ms"].as_u64().unwrap() > 0);
+    assert!(
+        stored.get("response_persisted_at_ms").is_none(),
+        "response stamp must be absent before the response leg"
+    );
+
+    let (get_status, get_body) = common::get_with_header(
+        &app,
+        &format!("/request/{request_id}"),
+        "Accept-IDKit-Flow-ID",
+        "true",
+    )
+    .await;
+    assert_eq!(get_status, 200);
+    let response: Value = serde_json::from_str(&get_body).expect("Failed to parse JSON");
+    assert_eq!(
+        response["idkit_flow_id"].as_str().unwrap(),
+        stored_flow_id,
+        "GET must return the persisted flow id, not a fresh one"
+    );
+
+    let alive: bool = redis.exists(format!("flow:{request_id}")).await.unwrap();
+    assert!(
+        alive,
+        "flow key must survive until the response is consumed"
+    );
+}
+
+/// PUT /response/:id stamps `response_persisted_at_ms` into the flow metadata;
+/// the consuming GET /response/:id deletes the flow key and never exposes the
+/// flow id to the RP.
+#[tokio::test]
+async fn test_flow_metadata_response_leg_and_cleanup() {
+    let app = common::test_app().await;
+    let mut redis = common::redis().await;
+
+    let (_, body) = common::post(&app, "/request", &json!({"iv": "a", "payload": "b"})).await;
+    let create_json: Value = serde_json::from_str(&body).expect("Failed to parse JSON");
+    let request_id = create_json["request_id"].as_str().unwrap().to_string();
+
+    let (get_status, _) = common::get(&app, &format!("/request/{request_id}")).await;
+    assert_eq!(get_status, 200);
+
+    let (put_status, _) = common::put(
+        &app,
+        &format!("/response/{request_id}"),
+        &json!({"iv": "r", "payload": "rp"}),
+    )
+    .await;
+    assert_eq!(put_status, 201);
+
+    let raw: Option<Vec<u8>> = redis.get(format!("flow:{request_id}")).await.unwrap();
+    let stored: Value =
+        serde_json::from_slice(&raw.expect("flow metadata must still exist after PUT")).unwrap();
+    assert!(
+        stored["response_persisted_at_ms"].as_u64().unwrap()
+            >= stored["request_persisted_at_ms"].as_u64().unwrap(),
+        "PUT /response must stamp the response-persisted timestamp"
+    );
+
+    let (get_status, get_body) = common::get(&app, &format!("/response/{request_id}")).await;
+    assert_eq!(get_status, 200);
+    let json: Value = serde_json::from_str(&get_body).expect("Failed to parse JSON");
+    assert_eq!(json["status"], "completed");
+    assert_eq!(json["response"]["iv"], "r");
+    assert!(
+        json.get("idkit_flow_id").is_none() && json["response"].get("idkit_flow_id").is_none(),
+        "the flow id must never be returned to the RP"
+    );
+
+    let alive: bool = redis.exists(format!("flow:{request_id}")).await.unwrap();
+    assert!(
+        !alive,
+        "flow key must be deleted once the response is consumed"
+    );
+}
+
+/// Missing flow metadata (expired mid-flow, or a request written by a bridge
+/// version that predates flow tracing) must degrade gracefully: the payload
+/// handoff succeeds end-to-end, just without a flow id.
+#[tokio::test]
+async fn test_missing_flow_metadata_degrades_gracefully() {
+    let app = common::test_app().await;
+    let mut redis = common::redis().await;
+
+    let (_, body) = common::post(&app, "/request", &json!({"iv": "a", "payload": "b"})).await;
+    let create_json: Value = serde_json::from_str(&body).expect("Failed to parse JSON");
+    let request_id = create_json["request_id"].as_str().unwrap().to_string();
+
+    redis
+        .del::<_, ()>(format!("flow:{request_id}"))
+        .await
+        .unwrap();
+
+    let (get_status, get_body) = common::get_with_header(
+        &app,
+        &format!("/request/{request_id}"),
+        "Accept-IDKit-Flow-ID",
+        "true",
+    )
+    .await;
+    assert_eq!(get_status, 200);
+    let response: Value = serde_json::from_str(&get_body).expect("Failed to parse JSON");
+    assert_eq!(response["iv"], "a");
+    assert!(
+        response.get("idkit_flow_id").is_none(),
+        "no persisted metadata means no flow id, even for opted-in clients"
+    );
+
+    let (put_status, _) = common::put(
+        &app,
+        &format!("/response/{request_id}"),
+        &json!({"iv": "r", "payload": "rp"}),
+    )
+    .await;
+    assert_eq!(put_status, 201);
+
+    let (get_status, get_body) = common::get(&app, &format!("/response/{request_id}")).await;
+    assert_eq!(get_status, 200);
+    let json: Value = serde_json::from_str(&get_body).expect("Failed to parse JSON");
+    assert_eq!(json["status"], "completed");
+}
+
+/// Standalone responses (POST /response) are out of flow-tracing scope: no
+/// flow metadata is minted and their consumption still works.
+#[tokio::test]
+async fn test_standalone_response_mints_no_flow_metadata() {
+    let app = common::test_app().await;
+    let mut redis = common::redis().await;
+
+    let (status, body) =
+        common::post(&app, "/response", &json!({"iv": "s", "payload": "sp"})).await;
+    assert_eq!(status, 201);
+    let create_json: Value = serde_json::from_str(&body).expect("Failed to parse JSON");
+    let request_id = create_json["request_id"].as_str().unwrap().to_string();
+
+    let exists: bool = redis.exists(format!("flow:{request_id}")).await.unwrap();
+    assert!(!exists, "standalone responses must not mint flow metadata");
+
+    let (get_status, get_body) = common::get(&app, &format!("/response/{request_id}")).await;
+    assert_eq!(get_status, 200);
+    let json: Value = serde_json::from_str(&get_body).expect("Failed to parse JSON");
+    assert_eq!(json["status"], "completed");
+    assert_eq!(json["response"]["iv"], "s");
 }


### PR DESCRIPTION
**Requestor/Issue:** [MCORE-1832](https://linear.app/worldcoin/issue/MCORE-1832/idkitbridge-mint-and-persist-idkit-flow-id-emit-handoff-metrics-and)

**Description/Why:**
The bridge emits JSON logs but no application metrics or traces, so we cannot measure the two asynchronous handoffs that define user-perceived bridge latency: how long a request waits between `POST /request` and its consuming `GET /request/:id`, and how long a response waits between `PUT /response/:id` and the poll that returns it. This implements the bridge side of [WDP85: IDKit Bridge tracing](https://app.notion.com/p/worldcoin/WDP85-IDKit-Bridge-tracing-3a38614bdf8c80108a8ad3d57dbf790c), replacing the fresh-mint-per-GET stub from #107 with a flow id that is minted at request creation and persisted for the life of the flow.

**Changes:**
- New `src/flow.rs`: `FlowMetadata {idkit_flow_id, request_persisted_at_ms, response_persisted_at_ms?}` stored at `flow:<request_id>` under the same uniform 900s TTL as the payload keys. All flow work is best-effort — telemetry failures are logged and swallowed so the payload handoff path can never fail because of tracing.
- `POST /request` (and staging `PUT /request/:id`) mints `idkitflow_<uuidv4>` after the payload is durably stored; emits the `wallet_bridge.request.create` span and `request_created` counter.
- `GET /request/:id` reads flow metadata in the existing Redis pipeline (with a TTL refresh so the flow key survives until the response leg), emits `handoff.duration_ms{leg:request}` / `request_consumed` / the `request.consume` span, and returns the **persisted** flow id behind the existing `accept-idkit-flow-id` opt-in header.
- `PUT /response/:id` stamps `response_persisted_at_ms` and refreshes the flow TTL (`response.create` span, `response_created` counter).
- The consuming `GET /response/:id` GETDELs the flow metadata and emits `handoff.duration_ms{leg:response}` / `response_consumed` / the `response.consume` span. The flow id is never returned to the RP. Pending polls and standalone `POST /response` are untouched (out of scope per WDP85).
- Privacy (Domain-5): spans carry `idkit_flow_id`, templated routes, status, Redis outcome, and `queue_age_ms` — never `request_id`, raw paths, or payload contents, so the `request_id → idkit_flow_id` join exists only in Redis. Metrics carry only bounded tags (`environment`, `leg`).
- Metrics go through `telemetry_batteries::reexports::metrics` (no new dependencies; a separately-versioned `metrics` crate would silently miss the statsd recorder). Span export activates via deployment env (`TELEMETRY_PRESET=datadog` + `TELEMETRY_SERVICE_NAME`) — no code change needed.
- Four new integration tests: flow-id stability POST→GET, response-leg stamping + cleanup + RP non-exposure, graceful degradation when metadata is missing, and standalone responses minting nothing.

**Testing:**
`cargo fmt -- --check`, `cargo clippy --all-features` (deny-all lint policy), `cargo build --locked`, and `cargo test` (32/32) against the docker-compose test Redis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)