### PR TITLE
feat: emit analytics event when response is consumed

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,4 @@
 ENVIRONMENT=development
 REDIS_URL=redis://localhost
+# Receives best-effort analytics callbacks when responses are fetched.
+ANALYTICS_CALLBACK_URL=https://analytics.example.com/events/response-fetched

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -766,6 +766,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1606,16 +1622,20 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tower",
  "tower-http",
  "tower-service",
@@ -1623,6 +1643,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2715,6 +2736,7 @@ dependencies = [
  "dotenvy",
  "http-body-util",
  "redis",
+ "reqwest",
  "rustls",
  "schemars",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ axum = "0.7.9"
 axum-jsonschema = { version = "0.8.0", features = ["aide"] }
 dotenvy = "0.15.7"
 redis = { version = "1.5.0", default-features = false, features = ["connection-manager", "tokio-rustls-comp", "tls-rustls-webpki-roots"] }
+reqwest = { version = "0.12.28", default-features = false, features = ["json", "rustls-tls-webpki-roots-no-provider"] }
 rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12", "logging"] }
 schemars = { version = "0.8.16", features = ["uuid1"] }
 serde = { version = "1.0.219", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ Bridge ->> IDKit: <response>
 - `POST /response`: Called by a client to create a standalone response without a prior request (see [Standalone Response Flow](#standalone-response-flow)).
 - `PUT /request/:id`: Staging only (`ENVIRONMENT == "staging"`). Idempotent request upsert.
 
+Response uploads may include an optional `tracking_receipt` alongside `iv` and
+`payload`. The receipt remains opaque, expires with the response, and is never
+returned to the response consumer. The bridge sends the receipt to the required
+`ANALYTICS_CALLBACK_URL` after the response is dequeued and decoded. Analytics
+delivery is best-effort and never blocks response delivery.
+
 ### Standalone Response Flow
 
 This flow allows a client to send a `/response` without first generating a `/request` first.

--- a/src/analytics.rs
+++ b/src/analytics.rs
@@ -1,0 +1,59 @@
+use std::time::Duration;
+
+use reqwest::{Client, Url};
+use serde::Serialize;
+
+const REQUEST_TIMEOUT: Duration = Duration::from_millis(500);
+
+#[derive(Clone, Debug)]
+pub struct Analytics {
+    client: Client,
+    response_fetched_url: Url,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ResponseFetchedEvent {
+    tracking_receipt: String,
+}
+
+impl Analytics {
+    /// Create an analytics client for the configured response-fetched URL.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the HTTP client cannot be built.
+    pub fn new(response_fetched_url: Url) -> Result<Self, reqwest::Error> {
+        let _provider_install_result = rustls::crypto::ring::default_provider().install_default();
+        let client = Client::builder().timeout(REQUEST_TIMEOUT).build()?;
+
+        Ok(Self {
+            client,
+            response_fetched_url,
+        })
+    }
+
+    pub fn send_response_fetched_event(&self, tracking_receipt: String) {
+        let client = self.client.clone();
+        let url = self.response_fetched_url.clone();
+        let _handle = tokio::spawn(async move {
+            let result = client
+                .post(url)
+                .json(&ResponseFetchedEvent { tracking_receipt })
+                .send()
+                .await;
+
+            match result {
+                Ok(response) if response.status().is_success() => {}
+                Ok(response) => tracing::warn!(
+                    status = %response.status(),
+                    "Failed to send response-fetched analytics event"
+                ),
+                Err(error) => tracing::warn!(
+                    error = %error,
+                    "Failed to send response-fetched analytics event"
+                ),
+            }
+        });
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,8 @@ use aide::openapi::{Info, License, OpenApi};
 use axum::{extract::DefaultBodyLimit, Extension};
 use redis::aio::ConnectionManager;
 
-use crate::utils::AppOverrides;
+pub mod analytics;
+use crate::{analytics::Analytics, utils::AppOverrides};
 
 pub(crate) mod observability;
 pub mod routes;
@@ -19,7 +20,11 @@ pub mod utils;
 /// both exercise the exact same routes, middleware stack, and `OpenAPI` document.
 /// Tests drive the returned router in-process with `tower::ServiceExt::oneshot`,
 /// so no separately-running bridge is required.
-pub fn app(redis: ConnectionManager, app_overrides: Arc<AppOverrides>) -> axum::Router {
+pub fn app(
+    redis: ConnectionManager,
+    app_overrides: Arc<AppOverrides>,
+    analytics: Arc<Analytics>,
+) -> axum::Router {
     let mut openapi = OpenApi {
         info: Info {
             title: "Message Bridge".to_string(),
@@ -40,6 +45,7 @@ pub fn app(redis: ConnectionManager, app_overrides: Arc<AppOverrides>) -> axum::
         .finish_api(&mut openapi)
         .layer(Extension(redis))
         .layer(Extension(app_overrides))
+        .layer(Extension(analytics))
         .layer(Extension(openapi))
         .layer(DefaultBodyLimit::max(5 * 1024 * 1024))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ use redis::aio::ConnectionManager;
 use std::env;
 use std::sync::Arc;
 
+use world_id_bridge::analytics::Analytics;
 use world_id_bridge::utils::AppOverrides;
 
 #[tokio::main]
@@ -50,8 +51,17 @@ async fn main() {
     tracing::info!("✅ Connection to Redis established.");
 
     let app_overrides = Arc::new(load_app_overrides());
+    let analytics = Arc::new(load_analytics());
 
-    world_id_bridge::server::start(redis, app_overrides).await;
+    world_id_bridge::server::start(redis, app_overrides, analytics).await;
+}
+
+fn load_analytics() -> Analytics {
+    let url = env::var("ANALYTICS_CALLBACK_URL")
+        .expect("ANALYTICS_CALLBACK_URL is required")
+        .parse()
+        .expect("ANALYTICS_CALLBACK_URL must be a valid URL");
+    Analytics::new(url).expect("Failed to build analytics client")
 }
 
 /// Load the per-`app_id` URL override map from the `APP_URL_OVERRIDES` env var.

--- a/src/routes/response/get.rs
+++ b/src/routes/response/get.rs
@@ -1,4 +1,4 @@
-use std::str::FromStr;
+use std::{str::FromStr, sync::Arc};
 
 use axum::{extract::Path, http::StatusCode, Extension};
 use axum_jsonschema::Json;
@@ -6,13 +6,14 @@ use redis::aio::ConnectionManager;
 use schemars::JsonSchema;
 
 use crate::{
+    analytics::Analytics,
     observability,
     utils::{
         handle_redis_error, validate_request_id, RequestPayload, RequestStatus, REQ_STATUS_PREFIX,
     },
 };
 
-use super::RES_PREFIX;
+use super::{StoredResponse, RES_PREFIX};
 
 #[derive(Debug, serde::Deserialize, serde::Serialize, JsonSchema)]
 pub(super) struct Response {
@@ -32,6 +33,7 @@ pub(super) struct Response {
 pub(super) async fn handler(
     Path(request_id): Path<String>,
     Extension(mut redis): Extension<ConnectionManager>,
+    Extension(analytics): Extension<Arc<Analytics>>,
 ) -> Result<Json<Response>, StatusCode> {
     let request_id = request_id.to_lowercase();
     validate_request_id(&request_id)?;
@@ -52,7 +54,7 @@ pub(super) async fn handler(
     observability::record_response_handoff(flow.as_deref());
 
     if let Some(value) = value {
-        let response =
+        let stored_response: StoredResponse =
             serde_json::from_slice(&value).map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
         // Cleanup is best effort after GETDEL: the correlation key has a
@@ -73,8 +75,12 @@ pub(super) async fn handler(
         telemetry_batteries::reexports::metrics::counter!("message_bridge.response_consumed")
             .increment(1);
 
+        if let Some(tracking_receipt) = stored_response.tracking_receipt {
+            analytics.send_response_fetched_event(tracking_receipt);
+        }
+
         return Ok(Json(Response {
-            response,
+            response: Some(stored_response.payload),
             status: RequestStatus::Completed,
         }));
     }

--- a/src/routes/response/mod.rs
+++ b/src/routes/response/mod.rs
@@ -3,7 +3,10 @@ use aide::axum::{
     ApiRouter,
 };
 use axum::http::Method;
+use schemars::JsonSchema;
 use tower_http::cors::{AllowHeaders, Any, CorsLayer};
+
+use crate::utils::RequestPayload;
 
 mod get;
 mod head;
@@ -11,6 +14,16 @@ mod post;
 mod put;
 
 pub(super) const RES_PREFIX: &str = "res:";
+
+#[derive(Debug, serde::Deserialize, serde::Serialize, JsonSchema)]
+pub(super) struct StoredResponse {
+    #[serde(flatten)]
+    pub(super) payload: RequestPayload,
+    /// Opaque analytics receipt supplied by the response producer. Stored
+    /// temporarily, but never returned to the response consumer.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) tracking_receipt: Option<String>,
+}
 
 pub fn handler() -> ApiRouter {
     let cors = CorsLayer::new()

--- a/src/routes/response/post.rs
+++ b/src/routes/response/post.rs
@@ -4,11 +4,9 @@ use redis::{aio::ConnectionManager, AsyncCommands};
 use schemars::JsonSchema;
 use uuid::Uuid;
 
-use crate::utils::{
-    handle_redis_error, RequestPayload, RequestStatus, EXPIRE_AFTER_SECONDS, REQ_STATUS_PREFIX,
-};
+use crate::utils::{handle_redis_error, RequestStatus, EXPIRE_AFTER_SECONDS, REQ_STATUS_PREFIX};
 
-use super::RES_PREFIX;
+use super::{StoredResponse, RES_PREFIX};
 
 #[derive(Debug, serde::Serialize, JsonSchema)]
 pub(super) struct ResponseCreatedPayload {
@@ -19,7 +17,7 @@ pub(super) struct ResponseCreatedPayload {
 /// Create a standalone response without `IDKit` flow correlation.
 pub(super) async fn handler(
     Extension(mut redis): Extension<ConnectionManager>,
-    Json(request): Json<RequestPayload>,
+    Json(request): Json<StoredResponse>,
 ) -> Result<(StatusCode, Json<ResponseCreatedPayload>), StatusCode> {
     let request_id = Uuid::new_v4().to_string();
 

--- a/src/routes/response/put.rs
+++ b/src/routes/response/put.rs
@@ -7,12 +7,12 @@ use redis::{aio::ConnectionManager, AsyncCommands, ExistenceCheck, SetExpiry, Se
 use crate::{
     observability,
     utils::{
-        handle_redis_error, validate_request_id, RequestPayload, RequestStatus,
-        EXPIRE_AFTER_SECONDS, REQ_STATUS_PREFIX,
+        handle_redis_error, validate_request_id, RequestStatus, EXPIRE_AFTER_SECONDS,
+        REQ_STATUS_PREFIX,
     },
 };
 
-use super::RES_PREFIX;
+use super::{StoredResponse, RES_PREFIX};
 
 #[tracing::instrument(
     parent = None,
@@ -26,7 +26,7 @@ use super::RES_PREFIX;
 pub(super) async fn handler(
     Path(request_id): Path<String>,
     Extension(mut redis): Extension<ConnectionManager>,
-    Json(request): Json<RequestPayload>,
+    Json(request): Json<StoredResponse>,
 ) -> Result<StatusCode, StatusCode> {
     let request_id = request_id.to_lowercase();
     validate_request_id(&request_id)?;

--- a/src/server.rs
+++ b/src/server.rs
@@ -3,7 +3,7 @@ use std::{env, net::SocketAddr, sync::Arc};
 use redis::aio::ConnectionManager;
 use tokio::{net::TcpListener, signal};
 
-use crate::utils::AppOverrides;
+use crate::{analytics::Analytics, utils::AppOverrides};
 
 /// Bind the configured address and serve the bridge until a shutdown signal.
 ///
@@ -11,8 +11,12 @@ use crate::utils::AppOverrides;
 ///
 /// Panics if `PORT` is set but not parseable as a port, if binding the TCP
 /// listener fails, or if the server exits with an error.
-pub async fn start(redis: ConnectionManager, app_overrides: Arc<AppOverrides>) {
-    let router = crate::app(redis, app_overrides);
+pub async fn start(
+    redis: ConnectionManager,
+    app_overrides: Arc<AppOverrides>,
+    analytics: Arc<Analytics>,
+) {
+    let router = crate::app(redis, app_overrides, analytics);
 
     let address = SocketAddr::from((
         [0, 0, 0, 0],

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -12,6 +12,7 @@ use http_body_util::BodyExt;
 use redis::aio::ConnectionManager;
 use serde_json::Value;
 use tower::ServiceExt;
+use world_id_bridge::analytics::Analytics;
 use world_id_bridge::app;
 use world_id_bridge::utils::{AppOverride, AppOverrides};
 
@@ -45,7 +46,29 @@ pub async fn redis_connection() -> ConnectionManager {
 
 /// Build the real bridge router, wired to a local Redis and the override fixture.
 pub async fn test_app() -> axum::Router {
-    app(redis_connection().await, Arc::new(fixture_overrides()))
+    let analytics_url = "http://127.0.0.1:1/analytics"
+        .parse()
+        .expect("test analytics URL must be valid");
+    let analytics = Analytics::new(analytics_url).expect("test analytics client must build");
+
+    app(
+        redis_connection().await,
+        Arc::new(fixture_overrides()),
+        Arc::new(analytics),
+    )
+}
+
+pub async fn test_app_with_analytics(callback_url: &str) -> axum::Router {
+    let url = callback_url
+        .parse()
+        .expect("test analytics URL must be valid");
+    let analytics = Analytics::new(url).expect("test analytics client must build");
+
+    app(
+        redis_connection().await,
+        Arc::new(fixture_overrides()),
+        Arc::new(analytics),
+    )
 }
 
 async fn send(

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,6 +1,14 @@
+use std::{sync::Arc, time::Duration};
+
+use axum::{
+    extract::State, http::StatusCode, routing::post as axum_post, Json as AxumJson, Router,
+};
 use serde_json::{json, Value};
-use std::sync::Arc;
-use tokio::sync::Barrier;
+use tokio::{
+    net::TcpListener,
+    sync::{mpsc, Barrier},
+    task::JoinHandle,
+};
 use uuid::Uuid;
 
 use redis::AsyncCommands;
@@ -26,6 +34,47 @@ async fn redis_ttl(key: &str) -> i64 {
 }
 
 mod common;
+
+const ANALYTICS_PATH: &str = "/analytics";
+
+async fn record_analytics(
+    State(sender): State<mpsc::UnboundedSender<Value>>,
+    AxumJson(body): AxumJson<Value>,
+) -> StatusCode {
+    sender.send(body).expect("analytics receiver must be open");
+    StatusCode::INTERNAL_SERVER_ERROR
+}
+
+async fn start_analytics_recorder() -> (String, mpsc::UnboundedReceiver<Value>, JoinHandle<()>) {
+    let (sender, receiver) = mpsc::unbounded_channel();
+    let router = Router::new()
+        .route(ANALYTICS_PATH, axum_post(record_analytics))
+        .with_state(sender);
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("analytics recorder must bind");
+    let address = listener
+        .local_addr()
+        .expect("analytics recorder must have an address");
+    let server = tokio::spawn(async move {
+        axum::serve(listener, router)
+            .await
+            .expect("analytics recorder must run");
+    });
+
+    (
+        format!("http://{address}{ANALYTICS_PATH}"),
+        receiver,
+        server,
+    )
+}
+
+async fn next_analytics_body(receiver: &mut mpsc::UnboundedReceiver<Value>) -> Value {
+    tokio::time::timeout(Duration::from_secs(1), receiver.recv())
+        .await
+        .expect("analytics callback was not received")
+        .expect("analytics recorder closed unexpectedly")
+}
 
 /// Test the root endpoint returns service information
 #[tokio::test]
@@ -220,6 +269,45 @@ async fn test_get_response() {
     assert_eq!(json["status"], "completed");
     assert_eq!(json["response"]["iv"], "resp_iv");
     assert_eq!(json["response"]["payload"], "resp_payload");
+}
+
+#[tokio::test]
+async fn test_response_fetch_calls_analytics_url() {
+    let (callback_url, mut analytics_bodies, server) = start_analytics_recorder().await;
+    let app = common::test_app_with_analytics(&callback_url).await;
+
+    let (upload_status, upload_body) = common::post(
+        &app,
+        "/response",
+        &json!({
+            "iv": "response-iv",
+            "payload": "response-payload",
+            "tracking_receipt": "opaque-receipt"
+        }),
+    )
+    .await;
+    assert_eq!(upload_status, 201);
+    let upload: Value = serde_json::from_str(&upload_body).unwrap();
+    let response_url = format!("/response/{}", upload["request_id"].as_str().unwrap());
+
+    let (fetch_status, fetch_body) = common::get(&app, &response_url).await;
+    assert_eq!(fetch_status, 200);
+    let response: Value = serde_json::from_str(&fetch_body).unwrap();
+    assert_eq!(
+        response,
+        json!({
+            "status": "completed",
+            "response": {"iv": "response-iv", "payload": "response-payload"}
+        })
+    );
+    assert_eq!(
+        next_analytics_body(&mut analytics_bodies).await,
+        json!({"trackingReceipt": "opaque-receipt"})
+    );
+
+    let (second_fetch_status, _) = common::get(&app, &response_url).await;
+    assert_eq!(second_fetch_status, 404);
+    server.abort();
 }
 
 /// Test GET /response/:id returns pending status when response not yet submitted


### PR DESCRIPTION
This PR adds an `analytics` module and emits a `response_fetched` event when the response is fetched. 

This allows authenticators to know when the ZK proof is fetched from an RP 